### PR TITLE
List file/folders inside a DukeDS project.

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets, status, permissions
-from util import get_user_projects
+from util import get_user_projects, get_user_project, get_user_project_content
 from rest_framework.response import Response
 from exceptions import DataServiceUnavailable
 from data.models import Workflow, WorkflowVersion, Job, JobInputFile, DDSJobInputFile, \
@@ -20,6 +20,14 @@ class ProjectsViewSet(viewsets.ViewSet):
             return Response(projects)
         except Exception as e:
             raise DataServiceUnavailable(e)
+
+    def retrieve(self, request, pk=None):
+        project_info = get_user_project(request.user, pk)
+        return Response(project_info)
+
+    @detail_route(methods=['get'])
+    def content(self, request, pk=None):
+        return Response(get_user_project_content(request.user, pk))
 
 
 class WorkflowsViewSet(viewsets.ModelViewSet):

--- a/data/api.py
+++ b/data/api.py
@@ -27,7 +27,8 @@ class ProjectsViewSet(viewsets.ViewSet):
 
     @detail_route(methods=['get'])
     def content(self, request, pk=None):
-        return Response(get_user_project_content(request.user, pk))
+        search_str = request.GET.get('search', '')
+        return Response(get_user_project_content(request.user, pk, search_str))
 
 
 class WorkflowsViewSet(viewsets.ModelViewSet):

--- a/data/exceptions.py
+++ b/data/exceptions.py
@@ -1,5 +1,15 @@
 from rest_framework.exceptions import APIException
 
+
 class DataServiceUnavailable(APIException):
     status_code = 503
     default_detail = 'Data Service temporarily unavailable, try again later.'
+
+
+class WrappedDataServiceException(APIException):
+    """
+    Converts error returned from DukeDS python code into one appropriate for django.
+    """
+    def __init__(self, data_service_exception):
+        self.status_code = data_service_exception.status_code
+        self.detail = data_service_exception.message

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -68,3 +68,15 @@ class ProjectsTestCase(APITestCase):
         url = reverse('project-list') + project_id + '/content/'
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch('data.api.get_user_project_content')
+    def testRetrieveProjectContentWithFilter(self, mock_get_user_project_content):
+        project_id = 'abc123'
+        mock_get_user_project_content.return_value = [{'id': '12355', 'name': 'test.txt'}]
+        url = reverse('project-list') + project_id + '/content/?search=test'
+        response = self.client.get(url, format='json')
+        mock, params = mock_get_user_project_content.call_args
+        user, project_id, search = mock
+        self.assertEqual('test', search)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -3,11 +3,12 @@ from rest_framework.test import APITestCase
 from rest_framework import status
 from django.contrib.auth.models import User as django_user
 from mock.mock import MagicMock, Mock, patch
+from exceptions import WrappedDataServiceException
 
 # Create your tests here.
 
-class ProjectsTestCase(APITestCase):
 
+class ProjectsTestCase(APITestCase):
     def setUp(self):
         username = 'username'
         password = 'secret'
@@ -28,3 +29,42 @@ class ProjectsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
 
+    @patch('data.api.get_user_project')
+    def testRetrieveProject(self, mock_get_user_project):
+        project_id = 'abc123'
+        mock_get_user_project.return_value = {'id': 'abc123', 'name': 'ProjectA'}
+        url = reverse('project-list') + project_id + '/'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], 'ProjectA')
+
+    @patch('data.api.get_user_project')
+    def testRetrieveProjectNotFound(self, mock_get_user_project):
+        project_id = 'abc123'
+        dds_error = MagicMock()
+        dds_error.status_code = 404
+        dds_error.message = 'Not Found'
+        mock_get_user_project.side_effect = WrappedDataServiceException(dds_error)
+        url = reverse('project-list') + project_id + '/'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch('data.api.get_user_project_content')
+    def testRetrieveProjectContent(self, mock_get_user_project_content):
+        project_id = 'abc123'
+        mock_get_user_project_content.return_value = [{'id': '12355', 'name': 'test.txt'}]
+        url = reverse('project-list') + project_id + '/content/'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    @patch('data.api.get_user_project_content')
+    def testRetrieveProjectContentNotFound(self, mock_get_user_project_content):
+        project_id = 'abc123'
+        dds_error = MagicMock()
+        dds_error.status_code = 404
+        dds_error.message = 'Not Found'
+        mock_get_user_project_content.side_effect = WrappedDataServiceException(dds_error)
+        url = reverse('project-list') + project_id + '/content/'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/data/util.py
+++ b/data/util.py
@@ -57,15 +57,16 @@ def get_user_project(user, dds_project_id):
         raise WrappedDataServiceException(dse)
 
 
-def get_user_project_content(user, dds_project_id):
+def get_user_project_content(user, dds_project_id, search_str=''):
     """
     Get all files and folders contained in a project (includes nested files and folders).
     :param user: User who has DukeDS credentials
     :param dds_project_id: str: duke data service project id
+    :param search_str: str: searches name of a file
     :return: [dict]: list of dicts for a file or folder
     """
     try:
         remote_store = get_remote_store(user)
-        return remote_store.data_service.get_project_children(dds_project_id, name_contains='').json()['results']
+        return remote_store.data_service.get_project_children(dds_project_id, name_contains=search_str).json()['results']
     except DataServiceError as dse:
         raise WrappedDataServiceException(dse)

--- a/data/util.py
+++ b/data/util.py
@@ -1,6 +1,8 @@
 from models import DDSUserCredential, DDSEndpoint
+from exceptions import WrappedDataServiceException
 from django.core.exceptions import PermissionDenied
 from ddsc.core.remotestore import RemoteStore
+from ddsc.core.ddsapi import DataServiceError
 from ddsc.config import Config
 
 
@@ -27,11 +29,43 @@ def get_remote_store(user):
     remote_store = RemoteStore(config)
     return remote_store
 
+
 def get_user_projects(user):
     """
     Get the Duke DS Projects for a user
-    :param user:
+    :param user: User who has DukeDS credentials
     :return: [dict] list of project metadata, including name and id
     """
-    remote_store = get_remote_store(user)
-    return remote_store.data_service.get_projects().json()['results']
+    try:
+        remote_store = get_remote_store(user)
+        return remote_store.data_service.get_projects().json()['results']
+    except DataServiceError as dse:
+        raise WrappedDataServiceException(dse)
+
+
+def get_user_project(user, dds_project_id):
+    """
+    Get a single Duke DS Project for a user
+    :param user: User who has DukeDS credentials
+    :param dds_project_id: str: duke data service project id
+    :return: dict: project details
+    """
+    try:
+        remote_store = get_remote_store(user)
+        return remote_store.data_service.get_project_by_id(dds_project_id).json()
+    except DataServiceError as dse:
+        raise WrappedDataServiceException(dse)
+
+
+def get_user_project_content(user, dds_project_id):
+    """
+    Get all files and folders contained in a project (includes nested files and folders).
+    :param user: User who has DukeDS credentials
+    :param dds_project_id: str: duke data service project id
+    :return: [dict]: list of dicts for a file or folder
+    """
+    try:
+        remote_store = get_remote_store(user)
+        return remote_store.data_service.get_project_children(dds_project_id, name_contains='').json()['results']
+    except DataServiceError as dse:
+        raise WrappedDataServiceException(dse)


### PR DESCRIPTION
Adds `/api/projects/<project_id>/` endpoint to view details for a single project.

Adds `/api/projects/<project_id>/content/` endpoint
Returns a the list of all files/folders in the DukeDS project.

Also has an optional search parameter to find files containing a string.
Example: Find files containing `mouse` in project `abc123`:
```
/api/projects/<project_id>/content/?search=mouse
```