### PR TITLE
Adds support for JSON API spec

### DIFF
--- a/bespin/settings.py
+++ b/bespin/settings.py
@@ -139,7 +139,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
     ),
-    'PAGE_SIZE': 10,
+    'PAGE_SIZE': 20,
     'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',
     'DEFAULT_PAGINATION_CLASS':
         'rest_framework_json_api.pagination.PageNumberPagination',
@@ -150,6 +150,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework_json_api.renderers.JSONRenderer',
+        'rest_framework.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',

--- a/bespin/settings.py
+++ b/bespin/settings.py
@@ -144,13 +144,14 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS':
         'rest_framework_json_api.pagination.PageNumberPagination',
     'DEFAULT_PARSER_CLASSES': (
+        'rest_framework.parsers.JSONParser',
         'rest_framework_json_api.parsers.JSONParser',
         'rest_framework.parsers.FormParser',
         'rest_framework.parsers.MultiPartParser'
     ),
     'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework_json_api.renderers.JSONRenderer',
         'rest_framework.renderers.JSONRenderer',
+        'rest_framework_json_api.renderers.JSONRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',

--- a/bespin/settings.py
+++ b/bespin/settings.py
@@ -140,7 +140,9 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
     ),
     'PAGE_SIZE': 20,
-    'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',
+    # Disabling the JSON API exception handler for now. Details in
+    # https://github.com/Duke-GCB/bespin-api/issues/10
+    # 'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',
     'DEFAULT_PAGINATION_CLASS':
         'rest_framework_json_api.pagination.PageNumberPagination',
     'DEFAULT_PARSER_CLASSES': (

--- a/bespin/settings.py
+++ b/bespin/settings.py
@@ -138,5 +138,19 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
-    )
+    ),
+    'PAGE_SIZE': 10,
+    'EXCEPTION_HANDLER': 'rest_framework_json_api.exceptions.exception_handler',
+    'DEFAULT_PAGINATION_CLASS':
+        'rest_framework_json_api.pagination.PageNumberPagination',
+    'DEFAULT_PARSER_CLASSES': (
+        'rest_framework_json_api.parsers.JSONParser',
+        'rest_framework.parsers.FormParser',
+        'rest_framework.parsers.MultiPartParser'
+    ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework_json_api.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ),
+    'DEFAULT_METADATA_CLASS': 'rest_framework_json_api.metadata.JSONAPIMetadata',
 }

--- a/data/api.py
+++ b/data/api.py
@@ -6,7 +6,7 @@ from data.models import Workflow, WorkflowVersion, Job, JobInputFile, DDSJobInpu
     DDSEndpoint, DDSUserCredential, URLJobInputFile, JobError
 from data.serializers import WorkflowSerializer, WorkflowVersionSerializer, JobSerializer, \
     DDSEndpointSerializer, DDSUserCredSerializer, JobInputFileSerializer, DDSJobInputFileSerializer, \
-    URLJobInputFileSerializer, JobErrorSerializer, AdminJobSerializer
+    URLJobInputFileSerializer, JobErrorSerializer, AdminJobSerializer, DDSProjectSerializer
 from data.serializers import AdminDDSUserCredSerializer
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.decorators import detail_route
@@ -15,17 +15,21 @@ from lando import LandoJob
 
 class ProjectsViewSet(viewsets.ViewSet):
     permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = DDSProjectSerializer
+    resource_name = 'projects'
 
     def list(self, request):
         try:
             projects = get_user_projects(request.user)
-            return Response(projects)
+            serializer = self.serializer_class(instance=projects, many=True)
+            return Response(serializer.data)
         except Exception as e:
             raise DataServiceUnavailable(e)
 
     def retrieve(self, request, pk=None):
-        project_info = get_user_project(request.user, pk)
-        return Response(project_info)
+        project = get_user_project(request.user, pk)
+        serializer = self.serializer_class(project)
+        return Response(serializer.data)
 
     @detail_route(methods=['get'])
     def content(self, request, pk=None):

--- a/data/api.py
+++ b/data/api.py
@@ -63,7 +63,7 @@ class JobsViewSet(viewsets.ModelViewSet):
         serializer.save(user=self.request.user)
 
     def get_queryset(self):
-        return Job.objects.all().filter(user=self.request.user)
+        return Job.objects.filter(user=self.request.user)
 
     @detail_route(methods=['post'])
     def start(self, request, pk=None):

--- a/data/api.py
+++ b/data/api.py
@@ -95,7 +95,7 @@ class DDSJobInputFileViewSet(viewsets.ModelViewSet):
     serializer_class = DDSJobInputFileSerializer
 
     def get_queryset(self):
-        return DDSJobInputFile.objects.all().filter(job_input_file__job__user=self.request.user)
+        return DDSJobInputFile.objects.filter(job_input_file__job__user=self.request.user)
 
 
 class JobInputFileViewSet(viewsets.ModelViewSet):
@@ -105,7 +105,7 @@ class JobInputFileViewSet(viewsets.ModelViewSet):
     filter_fields = ('job',)
 
     def get_queryset(self):
-        return JobInputFile.objects.all().filter(job__user=self.request.user)
+        return JobInputFile.objects.filter(job__user=self.request.user)
 
 
 class AdminJobInputFileViewSet(viewsets.ReadOnlyModelViewSet):

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -103,6 +103,16 @@ class AdminDDSEndpointSerializer(serializers.HyperlinkedModelSerializer):
 
 class AdminDDSUserCredSerializer(serializers.ModelSerializer):
     endpoint = AdminDDSEndpointSerializer()
+
     class Meta:
         model = DDSUserCredential
         fields = ('id', 'user', 'token', 'endpoint')
+
+
+class DDSProjectSerializer(serializers.Serializer):
+    """
+    Serializer for dds_resources.DDSProject
+    """
+    pk = serializers.UUIDField()
+    name = serializers.CharField()
+    description = serializers.CharField()

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -3,14 +3,14 @@ from data.models import Workflow, WorkflowVersion, Job, JobInputFile, DDSJobInpu
     DDSEndpoint, DDSUserCredential, JobOutputDir, URLJobInputFile, JobError
 
 
-class WorkflowSerializer(serializers.HyperlinkedModelSerializer):
+class WorkflowSerializer(serializers.ModelSerializer):
     class Meta:
         model = Workflow
         fields = ('id', 'name', 'versions')
         read_only_fields = ('versions',)
 
 
-class WorkflowVersionSerializer(serializers.HyperlinkedModelSerializer):
+class WorkflowVersionSerializer(serializers.ModelSerializer):
     class Meta:
         model = WorkflowVersion
         fields = ('id', 'workflow', 'object_name', 'created', 'url', 'version')
@@ -44,7 +44,7 @@ class AdminJobSerializer(serializers.ModelSerializer):
                   'vm_flavor', 'vm_instance_name', 'vm_project_name', 'workflow_input_json', 'output_dir')
 
 
-class DDSEndpointSerializer(serializers.HyperlinkedModelSerializer):
+class DDSEndpointSerializer(serializers.ModelSerializer):
     class Meta:
         model = DDSEndpoint
         fields = ('id', 'name', 'api_root')

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -2,7 +2,7 @@ from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.contrib.auth.models import User as django_user
-from mock.mock import MagicMock, patch
+from mock.mock import MagicMock, patch, Mock
 from data.models import Workflow, WorkflowVersion, Job, JobInputFile, JobError, \
     DDSUserCredential, DDSEndpoint, DDSJobInputFile, URLJobInputFile
 from exceptions import WrappedDataServiceException
@@ -470,8 +470,8 @@ class DDSJobInputFileTestCase(APITestCase):
         self.assertEqual(1, len(DDSJobInputFile.objects.all()))
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(1, len(response.data))
-        self.assertEqual('data.txt', response.data[0]['destination_path'])
+        self.assertEqual(1, len(response.data['results']))
+        self.assertEqual('data.txt', response.data['results'][0]['destination_path'])
 
 
 class URLJobInputFileTestCase(APITestCase):
@@ -502,5 +502,5 @@ class URLJobInputFileTestCase(APITestCase):
         self.assertEqual(1, len(URLJobInputFile.objects.all()))
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(1, len(response.data))
-        self.assertEqual('http://stuff.com/data.txt', response.data[0]['url'])
+        self.assertEqual(1, len(response.data['results']))
+        self.assertEqual('http://stuff.com/data.txt', response.data['results'][0]['url'])

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -53,7 +53,7 @@ class ProjectsTestCase(APITestCase):
 
     @patch('data.api.get_user_projects')
     def testListProjects(self, mock_get_user_projects):
-        mock_get_user_projects.return_value = [{'id':'abc123','name':'ProjectA'}, {'id':'def567','name':'ProjectB'}]
+        mock_get_user_projects.return_value = [Mock(id='abc123'), Mock(id='def567')]
         url = reverse('project-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -62,7 +62,10 @@ class ProjectsTestCase(APITestCase):
     @patch('data.api.get_user_project')
     def testRetrieveProject(self, mock_get_user_project):
         project_id = 'abc123'
-        mock_get_user_project.return_value = {'id': 'abc123', 'name': 'ProjectA'}
+        mock_dds_project = Mock()
+        # name is special on instantiation, so configure()
+        mock_dds_project.configure_mock(id=project_id, name='ProjectA')
+        mock_get_user_project.return_value = mock_dds_project
         url = reverse('project-list') + project_id + '/'
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -186,8 +189,8 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(1, len(response.data))
-        self.assertEqual(normal_user.id, response.data[0]['user_id'])
+        self.assertEqual(1, len(response.data['results']))
+        self.assertEqual(normal_user.id, response.data['results'][0]['user_id'])
 
         other_user = self.user_login.become_other_normal_user()
         response = self.client.post(url, format='json',
@@ -199,8 +202,8 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(1, len(response.data))
-        self.assertEqual(other_user.id, response.data[0]['user_id'])
+        self.assertEqual(1, len(response.data['results']))
+        self.assertEqual(other_user.id, response.data['results'][0]['user_id'])
 
     def testAdminSeeAllData(self):
         url = reverse('job-list')
@@ -232,9 +235,9 @@ class JobsTestCase(APITestCase):
         url = reverse('admin_job-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(2, len(response.data))
-        self.assertIn(other_user.id, [item['user_id'] for item in response.data])
-        self.assertIn(normal_user.id, [item['user_id'] for item in response.data])
+        self.assertEqual(2, len(response.data['results']))
+        self.assertIn(other_user.id, [item['user_id'] for item in response.data['results']])
+        self.assertIn(normal_user.id, [item['user_id'] for item in response.data['results']])
 
     def testStopRegularUserFromSettingStateOrStep(self):
         """
@@ -362,14 +365,14 @@ class JobInputFilesTestCase(APITestCase):
         url = reverse('jobinputfile-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(1, len(response.data))
+        self.assertEqual(1, len(response.data['results']))
 
         # Admin endpoint shows all user's data
         self.user_login.become_admin_user()
         url = reverse('admin_jobinputfile-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(2, len(response.data))
+        self.assertEqual(2, len(response.data['results']))
 
 
 class JobErrorTestCase(APITestCase):
@@ -404,14 +407,14 @@ class JobErrorTestCase(APITestCase):
         url = reverse('joberror-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(1, len(response.data))
+        self.assertEqual(1, len(response.data['results']))
 
         # Admin endpoint shows all user's data
         self.user_login.become_admin_user()
         url = reverse('admin_joberror-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(2, len(response.data))
+        self.assertEqual(2, len(response.data['results']))
 
     def testNormalEndpointNoWrite(self):
         self.user_login.become_normal_user()

--- a/data/util.py
+++ b/data/util.py
@@ -5,6 +5,21 @@ from ddsc.core.remotestore import RemoteStore
 from ddsc.core.ddsapi import DataServiceError
 from ddsc.config import Config
 
+class DDSProject(object):
+    """
+    A simple object to represent a DDSProject, including a pk field
+    for easier serialization with JSON API
+    """
+
+    def __init__(self, project_dict):
+        self.pk = project_dict.get('id')
+        self.name = project_dict.get('name')
+        self.description = project_dict.get('description')
+
+    @classmethod
+    def from_list(cls, project_dicts):
+        return [cls(p) for p in project_dicts]
+
 
 def get_remote_store(user):
     """
@@ -34,11 +49,12 @@ def get_user_projects(user):
     """
     Get the Duke DS Projects for a user
     :param user: User who has DukeDS credentials
-    :return: [dict] list of project metadata, including name and id
+    :return: [DDSProject] list of projects, including name, description, and id
     """
     try:
         remote_store = get_remote_store(user)
-        return remote_store.data_service.get_projects().json()['results']
+        projects = remote_store.data_service.get_projects().json()
+        return DDSProject.from_list(projects['results'])
     except DataServiceError as dse:
         raise WrappedDataServiceException(dse)
 
@@ -48,11 +64,12 @@ def get_user_project(user, dds_project_id):
     Get a single Duke DS Project for a user
     :param user: User who has DukeDS credentials
     :param dds_project_id: str: duke data service project id
-    :return: dict: project details
+    :return: DDSProject: project details
     """
     try:
         remote_store = get_remote_store(user)
-        return remote_store.data_service.get_project_by_id(dds_project_id).json()
+        project = remote_store.data_service.get_project_by_id(dds_project_id).json()
+        return DDSProject(project)
     except DataServiceError as dse:
         raise WrappedDataServiceException(dse)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,14 @@ Django==1.10.1
 django-cors-headers==1.3.1
 django-filter==1.0.1
 djangorestframework==3.4.7
+djangorestframework-jsonapi==2.1.1
 DukeDSClient==0.2.14
 funcsigs==1.0.2
+inflection==0.3.1
+lando-messaging==0.1
 mock==2.0.0
 pbr==1.10.0
+pika==0.10.0
 PyYAML==3.12
 requests==2.11.1
 six==1.10.0
-git+git://github.com/Duke-GCB/lando-messaging.git
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ djangorestframework-jsonapi==2.1.1
 DukeDSClient==0.2.14
 funcsigs==1.0.2
 inflection==0.3.1
-lando-messaging==0.1
+-e git+https://github.com/Duke-GCB/lando-messaging.git@06dd93b1cde8083e4a11c96f3f3e77658932c674#egg=lando_messaging-master
 mock==2.0.0
 pbr==1.10.0
 pika==0.10.0


### PR DESCRIPTION
Improves compatibility with Ember framework by supporting JSON API spec using django-rest-framework-json-api

- To get JSON API compatible responses, specify an `Accept: application/vnd.api+json` header
- When providing JSON API data to the API, specify `application/vnd.api+json` as the content type

By default (or explicitly with `Accept: application/json`) the API will still use the DRF standard JSONRenderer, but list endpoints will be paginated. For example, `/api/workflows` will return an object (instead of a list), containing keys for `meta`, `results`, and `links`

From discussion in #7 
> I found this post from a couple years ago: http://ngenworks.com/technology/making-ember-data-and-django-rest-framework-play-nice/. Their solution is to use the [JSON API](http://jsonapi.org) spec, which Ember supports through the [JSONAPIAdapter](http://emberjs.com/api/data/classes/DS.JSONAPIAdapter.html) and DRF supports via their published [django-rest-framework-json-api](https://github.com/django-json-api/django-rest-framework-json-api) package.