### PR TITLE
Adds dds-resources endpoint for browsing DDS projects/folders

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -10,7 +10,7 @@ from rest_framework.decorators import detail_route
 from lando import LandoJob
 
 
-class DDSOperationMixin(object):
+class DDSViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
 
     def _ds_operation(self, func, *args):
@@ -22,9 +22,9 @@ class DDSOperationMixin(object):
             raise DataServiceUnavailable(e)
 
 
-class DDSProjectsViewSet(DDSOperationMixin, viewsets.ReadOnlyModelViewSet):
+class DDSProjectsViewSet(DDSViewSet):
     """
-    This class interfaces with DukeDS API to provide project listing and details.
+    Interfaces with DukeDS API to provide project listing and details.
     Though it is not backed by django models, the ReadOnlyModelViewSet base class
     still works well
     """
@@ -38,7 +38,12 @@ class DDSProjectsViewSet(DDSOperationMixin, viewsets.ReadOnlyModelViewSet):
         return self._ds_operation(get_user_project, self.request.user, project_id)
 
 
-class DDSResourcesViewSet(DDSOperationMixin, viewsets.ReadOnlyModelViewSet):
+class DDSResourcesViewSet(DDSViewSet):
+    """
+    Interfaces with DukeDS API to list files and folders using query parameters. To list the root level
+    of a project, GET with ?project_id=:project_id, and to list a folder within a project,
+    GET with ?folder_id=:folder_id
+    """
     serializer_class = DDSResourceSerializer
 
     def get_queryset(self):

--- a/data/api.py
+++ b/data/api.py
@@ -10,7 +10,7 @@ from rest_framework.decorators import detail_route
 from lando import LandoJob
 
 
-class DDSReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
+class DDSOperationMixin(object):
     permission_classes = (permissions.IsAuthenticated,)
 
     def _ds_operation(self, func, *args):
@@ -22,7 +22,7 @@ class DDSReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
             raise DataServiceUnavailable(e)
 
 
-class DDSProjectsViewSet(DDSReadOnlyViewSet):
+class DDSProjectsViewSet(DDSOperationMixin, viewsets.ReadOnlyModelViewSet):
     """
     This class interfaces with DukeDS API to provide project listing and details.
     Though it is not backed by django models, the ReadOnlyModelViewSet base class
@@ -36,6 +36,14 @@ class DDSProjectsViewSet(DDSReadOnlyViewSet):
     def get_object(self):
         project_id = self.kwargs.get('pk')
         return self._ds_operation(get_user_project, self.request.user, project_id)
+
+
+class DDSProjectContentsViewSet(DDSOperationMixin, viewsets.mixins.RetrieveModelMixin, viewsets.GenericViewSet ):
+    serializer_class = DDSProjectContentSerializer
+
+    def get_object(self):
+        project_id = self.kwargs.get('pk')
+        return self._ds_operation(get_user_project_content, self.request.user, project_id)
 
 
 class WorkflowsViewSet(viewsets.ReadOnlyModelViewSet):

--- a/data/exceptions.py
+++ b/data/exceptions.py
@@ -13,3 +13,9 @@ class WrappedDataServiceException(APIException):
     def __init__(self, data_service_exception):
         self.status_code = data_service_exception.status_code
         self.detail = data_service_exception.message
+
+
+class BespinAPIException(APIException):
+    def __init__(self, status_code, detail):
+        self.status_code = status_code
+        self.detail = detail

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -152,6 +152,7 @@ class DDSResourceSerializer(serializers.Serializer):
     kind = serializers.CharField()
     id = serializers.UUIDField()
     name = serializers.CharField()
+    project = serializers.UUIDField()
 
     class Meta:
         resource_name = 'dds-resources'

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -145,4 +145,4 @@ class DDSProjectSerializer(serializers.Serializer):
     description = serializers.CharField()
 
     class Meta:
-        resource_name = 'projects'
+        resource_name = 'dds-projects'

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -146,3 +146,21 @@ class DDSProjectSerializer(serializers.Serializer):
 
     class Meta:
         resource_name = 'dds-projects'
+
+
+class DDSResourceSerializer(serializers.Serializer):
+    kind = serializers.CharField()
+    id = serializers.UUIDField()
+    name = serializers.CharField()
+    ancestors = serializers.ListField()
+
+    class Meta:
+        resource_name = 'dds-resources'
+
+
+class DDSProjectContentSerializer(serializers.Serializer):
+    project = serializers.UUIDField()
+    children = DDSResourceSerializer(many=True)
+
+    class Meta:
+        resource_name = 'dds-project-contents'

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -152,15 +152,6 @@ class DDSResourceSerializer(serializers.Serializer):
     kind = serializers.CharField()
     id = serializers.UUIDField()
     name = serializers.CharField()
-    ancestors = serializers.ListField()
 
     class Meta:
         resource_name = 'dds-resources'
-
-
-class DDSProjectContentSerializer(serializers.Serializer):
-    project = serializers.UUIDField()
-    children = DDSResourceSerializer(many=True)
-
-    class Meta:
-        resource_name = 'dds-project-contents'

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -98,7 +98,7 @@ class DDSResourcesTestCase(APITestCase):
     @patch('data.api.get_user_project_content')
     def testListsResourcesByProject(self, mock_get_user_project_content):
         project_id = 'abc123'
-        mock_get_user_project_content.return_value = DDSResource.from_list([{'id': '12355', 'name': 'test.txt'}])
+        mock_get_user_project_content.return_value = DDSResource.from_list([{'id': '12355', 'name': 'test.txt', 'project': {'id': project_id}}])
         url = reverse('dds-resources-list')
         response = self.client.get(url, data={'project_id': project_id}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -106,8 +106,9 @@ class DDSResourcesTestCase(APITestCase):
 
     @patch('data.api.get_user_folder_content')
     def testListsResourcesByFolder(self, mock_get_user_folder_content):
+        project_id = 'abc123'
         folder_id = 'def456'
-        mock_get_user_folder_content.return_value = DDSResource.from_list([{'id': '12355', 'name': 'test.txt'}])
+        mock_get_user_folder_content.return_value = DDSResource.from_list([{'id': '12355', 'name': 'test.txt', 'project': {'id': project_id}}])
         url = reverse('dds-resources-list')
         response = self.client.get(url, data={'folder_id': folder_id}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/data/urls.py
+++ b/data/urls.py
@@ -4,6 +4,7 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'dds-projects', api.DDSProjectsViewSet, 'dds-projects')
+router.register(r'dds-project-contents', api.DDSProjectContentsViewSet, 'dds-project-contents')
 router.register(r'workflows', api.WorkflowsViewSet, 'workflow')
 router.register(r'workflow-versions', api.WorkflowVersionsViewSet, 'workflowversion')
 router.register(r'jobs', api.JobsViewSet, 'job')

--- a/data/urls.py
+++ b/data/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url, include
 from rest_framework import routers
 
 router = routers.DefaultRouter()
-router.register(r'projects', api.ProjectsViewSet, 'project')
+router.register(r'dds-projects', api.DDSProjectsViewSet, 'dds-projects')
 router.register(r'workflows', api.WorkflowsViewSet, 'workflow')
 router.register(r'workflow-versions', api.WorkflowVersionsViewSet, 'workflowversion')
 router.register(r'jobs', api.JobsViewSet, 'job')

--- a/data/urls.py
+++ b/data/urls.py
@@ -4,7 +4,7 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 router.register(r'dds-projects', api.DDSProjectsViewSet, 'dds-projects')
-router.register(r'dds-project-contents', api.DDSProjectContentsViewSet, 'dds-project-contents')
+router.register(r'dds-resources', api.DDSResourcesViewSet, 'dds-resources')
 router.register(r'workflows', api.WorkflowsViewSet, 'workflow')
 router.register(r'workflow-versions', api.WorkflowVersionsViewSet, 'workflowversion')
 router.register(r'jobs', api.JobsViewSet, 'job')

--- a/data/util.py
+++ b/data/util.py
@@ -28,13 +28,6 @@ class DDSResource(DDSBase):
         self.id = resource_dict.get('id')
         self.name = resource_dict.get('name')
         self.kind = resource_dict.get('kind')
-        self.ancestors = resource_dict.get('ancestors')
-
-class DDSProjectContent(object):
-
-    def __init__(self, project, children=[]):
-        self.project = project
-        self.children = children
 
 
 def get_remote_store(user):
@@ -90,7 +83,7 @@ def get_user_project(user, dds_project_id):
         raise WrappedDataServiceException(dse)
 
 
-def get_user_project_content(user, dds_project_id, search_str=''):
+def get_user_project_content(user, dds_project_id, search_str=None):
     """
     Get all files and folders contained in a project (includes nested files and folders).
     :param user: User who has DukeDS credentials
@@ -100,8 +93,23 @@ def get_user_project_content(user, dds_project_id, search_str=''):
     """
     try:
         remote_store = get_remote_store(user)
-        children = remote_store.data_service.get_project_children(dds_project_id, name_contains=search_str).json()['results']
-        children = DDSResource.from_list(children)
-        return DDSProjectContent(dds_project_id, children)
+        resources = remote_store.data_service.get_project_children(dds_project_id, name_contains=search_str).json()['results']
+        return DDSResource.from_list(resources)
+    except DataServiceError as dse:
+        raise WrappedDataServiceException(dse)
+
+
+def get_user_folder_content(user, dds_folder_id, search_str=None):
+    """
+    Get all files and folders contained in a project (includes nested files and folders).
+    :param user: User who has DukeDS credentials
+    :param dds_folder_id: str: duke data service folder id
+    :param search_str: str: searches name of a file
+    :return: [dict]: list of dicts for a file or folder
+    """
+    try:
+        remote_store = get_remote_store(user)
+        resources = remote_store.data_service.get_folder_children(dds_folder_id, name_contains=search_str).json()['results']
+        return DDSResource.from_list(resources)
     except DataServiceError as dse:
         raise WrappedDataServiceException(dse)

--- a/data/util.py
+++ b/data/util.py
@@ -83,6 +83,7 @@ def get_user_project_content(user, dds_project_id, search_str=''):
     """
     try:
         remote_store = get_remote_store(user)
-        return remote_store.data_service.get_project_children(dds_project_id, name_contains=search_str).json()['results']
+        children = remote_store.data_service.get_project_children(dds_project_id, name_contains=search_str).json()['results']
+        return DDSProjectContent(dds_project_id, children)
     except DataServiceError as dse:
         raise WrappedDataServiceException(dse)

--- a/data/util.py
+++ b/data/util.py
@@ -28,6 +28,7 @@ class DDSResource(DDSBase):
         self.id = resource_dict.get('id')
         self.name = resource_dict.get('name')
         self.kind = resource_dict.get('kind')
+        self.project = resource_dict.get('project').get('id')
 
 
 def get_remote_store(user):

--- a/data/util.py
+++ b/data/util.py
@@ -5,7 +5,13 @@ from ddsc.core.remotestore import RemoteStore
 from ddsc.core.ddsapi import DataServiceError
 from ddsc.config import Config
 
-class DDSProject(object):
+class DDSBase(object):
+    @classmethod
+    def from_list(cls, project_dicts):
+        return [cls(p) for p in project_dicts]
+
+
+class DDSProject(DDSBase):
     """
     A simple object to represent a DDSProject
     """
@@ -15,9 +21,20 @@ class DDSProject(object):
         self.name = project_dict.get('name')
         self.description = project_dict.get('description')
 
-    @classmethod
-    def from_list(cls, project_dicts):
-        return [cls(p) for p in project_dicts]
+
+class DDSResource(DDSBase):
+
+    def __init__(self, resource_dict):
+        self.id = resource_dict.get('id')
+        self.name = resource_dict.get('name')
+        self.kind = resource_dict.get('kind')
+        self.ancestors = resource_dict.get('ancestors')
+
+class DDSProjectContent(object):
+
+    def __init__(self, project, children=[]):
+        self.project = project
+        self.children = children
 
 
 def get_remote_store(user):
@@ -84,6 +101,7 @@ def get_user_project_content(user, dds_project_id, search_str=''):
     try:
         remote_store = get_remote_store(user)
         children = remote_store.data_service.get_project_children(dds_project_id, name_contains=search_str).json()['results']
+        children = DDSResource.from_list(children)
         return DDSProjectContent(dds_project_id, children)
     except DataServiceError as dse:
         raise WrappedDataServiceException(dse)


### PR DESCRIPTION
- Adds `dds-resources` endpoint. It returns a list of dds-files and dds-folders, provided a `project_id` or `folder_id` is passed as a query parameter
 Renames `projects` endpoint to `dds-projects`