### PR TITLE
Add name parameter to /api/admin/jobs/<id> GET

### DIFF
--- a/data/serializers.py
+++ b/data/serializers.py
@@ -54,10 +54,11 @@ class AdminJobSerializer(serializers.ModelSerializer):
     output_dir = JobOutputDirSerializer(required=False, read_only=True)
     vm_project_name = serializers.CharField(required=False)
     user_id = serializers.IntegerField(required=False)
+    name = serializers.CharField(required=False)
     class Meta:
         model = Job
         resource_name = 'jobs'
-        fields = ('id', 'workflow_version', 'user_id', 'created', 'state', 'step', 'last_updated',
+        fields = ('id', 'workflow_version', 'user_id', 'name', 'created', 'state', 'step', 'last_updated',
                   'vm_flavor', 'vm_instance_name', 'vm_project_name', 'job_order', 'output_dir')
 
 

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -14,10 +14,15 @@ class WorkflowSerializer(serializers.ModelSerializer):
 
 
 class WorkflowVersionSerializer(serializers.ModelSerializer):
+    name = serializers.SerializerMethodField()
+
+    def get_name(self, obj):
+        return obj.workflow.name
+
     class Meta:
         model = WorkflowVersion
         resource_name = 'workflow-versions'
-        fields = ('id', 'workflow', 'description', 'object_name', 'created', 'url', 'version')
+        fields = ('id', 'workflow', 'name', 'description', 'object_name', 'created', 'url', 'version')
 
 
 class JobOutputDirSerializer(serializers.ModelSerializer):

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -300,7 +300,7 @@ class JobsTestCase(APITestCase):
         response = self.client.post(url, format='json',
                                     data={
                                         'name': 'my job',
-                                        'workflow_version_id': self.workflow_version.id,
+                                        'workflow_version': self.workflow_version.id,
                                         'vm_project_name': 'jpb67',
                                         'job_order': '{}',
                                     })
@@ -310,12 +310,13 @@ class JobsTestCase(APITestCase):
         self.assertEqual(1, len(response.data))
         self.assertEqual(normal_user.id, response.data[0]['user'])
         self.assertEqual('my job', response.data[0]['name'])
+        self.assertEqual(self.workflow_version.id, response.data[0]['workflow_version'])
 
         other_user = self.user_login.become_other_normal_user()
         response = self.client.post(url, format='json',
                             data={
                                 'name': 'my job2',
-                                'workflow_version_id': self.workflow_version.id,
+                                'workflow_version': self.workflow_version.id,
                                 'vm_project_name': 'jpb88',
                                 'job_order': '{}',
                             })
@@ -324,6 +325,7 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(1, len(response.data))
         self.assertEqual(other_user.id, response.data[0]['user'])
+        self.assertEqual(self.workflow_version.id, response.data[0]['workflow_version'])
 
     def testAdminSeeAllData(self):
         url = reverse('job-list')
@@ -331,7 +333,7 @@ class JobsTestCase(APITestCase):
         response = self.client.post(url, format='json',
                                     data={
                                         'name': 'my job',
-                                        'workflow_version_id': self.workflow_version.id,
+                                        'workflow_version': self.workflow_version.id,
                                         'vm_project_name': 'jpb67',
                                         'job_order': '{}',
                                     })
@@ -346,7 +348,7 @@ class JobsTestCase(APITestCase):
         response = self.client.post(url, format='json',
                             data={
                                 'name': 'my job2',
-                                'workflow_version_id': self.workflow_version.id,
+                                'workflow_version': self.workflow_version.id,
                                 'vm_project_name': 'jpb88',
                                 'job_order': '{}',
                             })
@@ -362,6 +364,8 @@ class JobsTestCase(APITestCase):
         self.assertIn(normal_user.id, [item['user_id'] for item in response.data])
         self.assertIn('my job', [item['name'] for item in response.data])
         self.assertIn('my job2', [item['name'] for item in response.data])
+        self.assertEqual(['RnaSeq', 'RnaSeq'], [item['workflow_version']['name'] for item in response.data])
+
 
     def testStopRegularUserFromSettingStateOrStep(self):
         """
@@ -372,7 +376,7 @@ class JobsTestCase(APITestCase):
         response = self.client.post(url, format='json',
                                     data={
                                         'name': 'my job',
-                                        'workflow_version_id': self.workflow_version.id,
+                                        'workflow_version': self.workflow_version.id,
                                         'vm_project_name': 'jpb67',
                                         'job_order': '{}',
                                         'state': Job.JOB_STATE_FINISHED,
@@ -472,7 +476,7 @@ class JobsTestCase(APITestCase):
         response = self.client.post(url, format='json',
                                     data={
                                         'name': 'my job',
-                                        'workflow_version_id': self.workflow_version.id,
+                                        'workflow_version': self.workflow_version.id,
                                         'vm_project_name': 'jpb67',
                                         'job_order': '{}',
                                     })

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -360,6 +360,8 @@ class JobsTestCase(APITestCase):
         self.assertEqual(2, len(response.data))
         self.assertIn(other_user.id, [item['user_id'] for item in response.data])
         self.assertIn(normal_user.id, [item['user_id'] for item in response.data])
+        self.assertIn('my job', [item['name'] for item in response.data])
+        self.assertIn('my job2', [item['name'] for item in response.data])
 
     def testStopRegularUserFromSettingStateOrStep(self):
         """
@@ -386,7 +388,8 @@ class JobsTestCase(APITestCase):
         Admin should be able to change job state and job step.
         """
         admin_user = self.user_login.become_admin_user()
-        job = Job.objects.create(workflow_version=self.workflow_version,
+        job = Job.objects.create(name='somejob',
+                                 workflow_version=self.workflow_version,
                                  vm_project_name='jpb67',
                                  job_order={},
                                  user=admin_user)


### PR DESCRIPTION
The name parameter was added to the /api/jobs/<id> serializer but not the admin endpoint.
