### PR TITLE
Provide serializer for /jobs/<job_id>/authorize/ payload

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -97,6 +97,9 @@ class JobsViewSet(viewsets.ModelViewSet):
         LandoJob(pk, request.user).restart()
         return self._serialize_job_response(pk)
 
+    # Wrapping this in JobTokensSerializer so we can pass in the token inside a job-tokens payload when
+    # used with vnd.rootobject+json Content-type. Returns serialized 'job' as part of the response inside the
+    # job-tokens payload when used with vnd.rootobject+json Accept.
     @detail_route(methods=['post'], serializer_class=JobTokensSerializer)
     def authorize(self, request, pk=None):
         """

--- a/data/api.py
+++ b/data/api.py
@@ -117,7 +117,8 @@ class JobsViewSet(viewsets.ModelViewSet):
             job.save()
         except IntegrityError:
             raise JobTokenException(detail='This token has already been used.')
-        return self._serialize_job_response(pk)
+        serializer = JobTokensSerializer(job.run_token)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @staticmethod
     def _serialize_job_response(pk, job_status=status.HTTP_200_OK):

--- a/data/api.py
+++ b/data/api.py
@@ -97,7 +97,7 @@ class JobsViewSet(viewsets.ModelViewSet):
         LandoJob(pk, request.user).restart()
         return self._serialize_job_response(pk)
 
-    @detail_route(methods=['post'])
+    @detail_route(methods=['post'], serializer_class=JobTokensSerializer)
     def authorize(self, request, pk=None):
         """
         Authorizes this job for running by supplying a valid job token.

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -236,4 +236,4 @@ class JobTokensSerializer(serializers.ModelSerializer):
     class Meta:
         model = JobToken
         resource_name = 'job-tokens'
-        fields = ('id', 'token', 'job')
+        fields = ('token', 'job')

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -229,3 +229,10 @@ class AdminJobTokensSerializer(serializers.ModelSerializer):
         resource_name = 'job-tokens'
         fields = ('id', 'token', 'job')
         read_only_fields = ('job',)
+
+
+class JobTokensSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = JobToken
+        resource_name = 'job-tokens'
+        fields = ('token',)

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -232,7 +232,8 @@ class AdminJobTokensSerializer(serializers.ModelSerializer):
 
 
 class JobTokensSerializer(serializers.ModelSerializer):
+    job = JobSerializer()
     class Meta:
         model = JobToken
         resource_name = 'job-tokens'
-        fields = ('token',)
+        fields = ('id', 'token', 'job')

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -549,6 +549,7 @@ class JobsTestCase(APITestCase):
         url = reverse('job-list') + str(job.id) + '/authorize/'
         response = self.client.post(url, format='json', data={'token': 'secret1'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['job']['id'], job.id)
 
     def test_authorize_with_good_token_but_bad_state(self):
         job_token = JobToken.objects.create(token='secret1')


### PR DESCRIPTION
Uses JobTokensSerializer that only supports a single 'token' value.
This is only used for the 'application/vnd.rootobject+json' media type.

Example input payload:
```
{
   "job-tokens": {
       "token": "secret-key-1"
   }
}
```

Example output payload:
Example input payload:
```
{
   "job-tokens": {
        ...
        "token"...
        "job": {
                 ... job details
        }
   }
}
```