### PR TITLE
require users to be in bespin-users group

### DIFF
--- a/bespin/backend.py
+++ b/bespin/backend.py
@@ -1,0 +1,13 @@
+from gcb_web_auth.backends.oauth import OAuth2Backend
+
+BESPIN_USER_GROUP = 'duke:group-manager:roles:bespin-users'
+
+
+class BespinOAuth2Backend(OAuth2Backend):
+    """
+    Adds check to make sure users belong to the bespin-user group manager group.
+    This group is managed via https://groups.oit.duke.edu/groupmanager/.
+    """
+    def check_user_details(self, details):
+        duke_unique_id = details['dukeUniqueID']
+        self.verify_user_belongs_to_group(duke_unique_id, BESPIN_USER_GROUP)

--- a/bespin/settings_base.py
+++ b/bespin/settings_base.py
@@ -109,7 +109,7 @@ STATICFILES_DIRS = [
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'gcb_web_auth.backends.oauth.OAuth2Backend',
+    'bespin.backend.BespinOAuth2Backend',
 ]
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Adds extra check to OAuth2 backend to check for a particular group.

Requires https://github.com/Duke-GCB/gcb-web-auth/pull/13