### PR TITLE
Bump gcb web auth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-filter==1.0.1
 djangorestframework==3.4.7
 DukeDSClient==0.2.14
 funcsigs==1.0.2
+gcb-web-auth==0.5
 inflection==0.3.1
 lando-messaging==0.7.2
 mock==2.0.0
@@ -16,4 +17,3 @@ PyYAML==3.12
 requests==2.11.1
 requests-oauthlib==0.7.0
 six==1.10.0
-gcb-web-auth==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ PyYAML==3.12
 requests==2.11.1
 requests-oauthlib==0.7.0
 six==1.10.0
-gcb-web-auth==0.4
+gcb-web-auth==0.5


### PR DESCRIPTION
Raises version of gcb-web-auth to 0.5, which includes group manager support