### PR TITLE
Remove dependencies that gcb-web-auth provides

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,13 @@ django-filter==1.0.1
 djangorestframework==3.4.7
 DukeDSClient==0.2.14
 funcsigs==1.0.2
-gcb-web-auth==0.5
+gcb-web-auth==0.5.1
 inflection==0.3.1
 lando-messaging==0.7.2
 mock==2.0.0
 pbr==1.10.0
 pika==0.10.0
 psycopg2==2.6.2
-PyJWT==1.4.2
 PyYAML==3.12
 requests==2.11.1
-requests-oauthlib==0.7.0
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Django==1.10.1
 django-cors-headers==1.3.1
 django-filter==1.0.1
 djangorestframework==3.4.7
-DukeDSClient==0.2.14
+DukeDSClient==0.3.16
 funcsigs==1.0.2
 gcb-web-auth==0.5.1
 inflection==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-filter==1.0.1
 djangorestframework==3.4.7
 DukeDSClient==0.3.16
 funcsigs==1.0.2
-gcb-web-auth==0.5.1
+gcb-web-auth==0.6
 inflection==0.3.1
 lando-messaging==0.7.2
 mock==2.0.0


### PR DESCRIPTION
- Depends on https://github.com/Duke-GCB/gcb-web-auth/pull/17
- The packages removed from requirements.txt are required by gcb-web-auth
- Since DukeDSClient is required by both, this synchronizes that version to 0.3.16

Tested locally with a fresh environment:

```
$ virtualenv webauth
$ source webauth/bin/activate
$ pip install ../gcb-web-auth/
$ pip install -r requirements.txt 
$ python -m requests_oauthlib
/Users/dcl9/Code/python/bespin-api/webauth/bin/python: No module named requests_oauthlib.__main__; 'requests_oauthlib' is a package and cannot be directly executed
```