### PR TITLE
Remove create, update, and delete from /api/jobs endpoit

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, permissions, status
+from rest_framework import viewsets, permissions, status, mixins
 from util import get_user_projects, get_user_project, get_user_project_content, get_user_folder_content
 from rest_framework.response import Response
 from exceptions import DataServiceUnavailable, WrappedDataServiceException, BespinAPIException, JobTokenException
@@ -75,7 +75,9 @@ class WorkflowVersionsViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = WorkflowVersionSerializer
 
 
-class JobsViewSet(viewsets.ModelViewSet):
+class JobsViewSet(mixins.RetrieveModelMixin,
+                  mixins.ListModelMixin,
+                  viewsets.GenericViewSet):
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = JobSerializer
 


### PR DESCRIPTION
These are all handled via the job questionnaire and
the job start/cancel/restart methods.
Fixes #54 