### PR TITLE
Adds manage.py command to create share groups

### DIFF
--- a/data/management/commands/_private.py
+++ b/data/management/commands/_private.py
@@ -1,6 +1,6 @@
 import sys
 
-class CommandLogger(object):
+class BaseCreator(object):
     """
     Base for command with simple logging facility
     """

--- a/data/management/commands/_private.py
+++ b/data/management/commands/_private.py
@@ -1,0 +1,25 @@
+import sys
+
+class CommandLogger(object):
+    """
+    Base for command with simple logging facility
+    """
+
+    def __init__(self, stdout=sys.stdout, stderr=sys.stderr):
+        """
+        Creates a base command logger  with logging IO streams
+        :param stdout: For writing info log messages
+        :param stderr: For writing error messages
+        """
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def log_creation(self, created, kind, name, id):
+        if created:
+            self.stdout.write("{} '{}' created with id {}".format(kind, name, id))
+        else:
+            self.stderr.write("{} '{}' already exists with id {}".format(kind, name, id))
+
+    def log(self, message):
+        self.stdout.write(message)
+

--- a/data/management/commands/loadworkflow.py
+++ b/data/management/commands/loadworkflow.py
@@ -3,6 +3,7 @@ from argparse import FileType
 from data.models import Workflow, WorkflowVersion, JobQuestionnaire, VMFlavor, VMProject
 from cwltool.load_tool import load_tool
 from cwltool.workflow import defaultMakeTool
+from _private import CommandLogger
 import json
 import sys
 
@@ -47,28 +48,7 @@ class CWLDocument(object):
         return self.parsed.tool.get(key)
 
 
-class BaseImporter(object):
-    """
-    Base for importer with simple logging facility
-    """
-
-    def __init__(self, stdout=sys.stdout, stderr=sys.stderr):
-        """
-        Creates a base importer with logging IO streams
-        :param stdout: For writing info log messages
-        :param stderr: For writing error messages
-        """
-        self.stdout = stdout
-        self.stderr = stderr
-
-    def log_creation(self, created, kind, name, id):
-        if created:
-            self.stdout.write("{} '{}' created with id {}".format(kind, name, id))
-        else:
-            self.stderr.write("{} '{}' already exists with id {}".format(kind, name, id))
-
-
-class JobQuestionnaireImporter(BaseImporter):
+class JobQuestionnaireImporter(CommandLogger):
     """
     Creates a JobQuestionnaire model for a WorkflowVersion with the supplied system job order
     """
@@ -128,7 +108,7 @@ class JobQuestionnaireImporter(BaseImporter):
         self.job_questionnaire.delete()
 
 
-class WorkflowImporter(BaseImporter):
+class WorkflowImporter(CommandLogger):
     """
     Creates Workflow and WorkflowVersion model objects from a CWL document and supplied version number
     """

--- a/data/management/commands/makesharegroup.py
+++ b/data/management/commands/makesharegroup.py
@@ -1,0 +1,45 @@
+from django.core.management.base import BaseCommand, CommandError
+from data.models import ShareGroup, DDSUser
+from _private import CommandLogger
+
+
+class Command(BaseCommand):
+    help = """Creates share groups with specified dds users"""
+
+    def __init__(self):
+        super(Command, self).__init__()
+        self.logger = CommandLogger(self.stdout, self.stderr)
+
+    def add_arguments(self, parser):
+        parser.add_argument('group_name', help='Name of the share group to create')
+        parser.add_argument('--usernames', help='User to add to share group', nargs='*')
+        parser.add_argument('--dds_ids', help='DukeDS UUID of user', nargs='*')
+
+    def _create_share_group(self, group_name):
+        share_group, created = ShareGroup.objects.get_or_create(name=group_name)
+        self.logger.log_creation(created, 'ShareGroup', group_name, share_group.id)
+        return share_group
+
+    def _create_dds_user(self, name, dds_id):
+        dds_user, created = DDSUser.objects.get_or_create(name=name, dds_id=dds_id)
+        self.logger.log_creation(created, 'DDSUser', name, dds_user.id)
+        return dds_user
+
+    def _add_dds_user_to_share_group(self, dds_user, share_group):
+        share_group.users.add(dds_user)
+        self.logger.log('Added {} to share group {}'.format(dds_user, share_group))
+
+    def handle(self, **options):
+        group_name = options['group_name']
+        usernames = options['usernames'] or []
+        dds_ids = options['dds_ids'] or []
+
+        if not len(usernames) == len(dds_ids):
+            raise CommandError('usernames and dds_ids must be equal length')
+
+        share_group = self._create_share_group(group_name)
+
+        for username, dds_id in zip(usernames, dds_ids):
+            dds_user = self._create_dds_user(username, dds_id)
+            self._add_dds_user_to_share_group(dds_user, share_group)
+

--- a/data/management/commands/makesharegroup.py
+++ b/data/management/commands/makesharegroup.py
@@ -1,6 +1,23 @@
 from django.core.management.base import BaseCommand, CommandError
 from data.models import ShareGroup, DDSUser
-from _private import CommandLogger
+from _private import BaseCreator
+
+
+class ShareGroupCreator(BaseCreator):
+
+    def create_share_group(self, group_name):
+        share_group, created = ShareGroup.objects.get_or_create(name=group_name)
+        self.log_creation(created, 'ShareGroup', group_name, share_group.id)
+        return share_group
+
+    def create_dds_user(self, name, dds_id):
+        dds_user, created = DDSUser.objects.get_or_create(name=name, dds_id=dds_id)
+        self.log_creation(created, 'DDSUser', name, dds_user.id)
+        return dds_user
+
+    def add_dds_user_to_share_group(self, dds_user, share_group):
+        share_group.users.add(dds_user)
+        self.log('Added {} to share group {}'.format(dds_user, share_group))
 
 
 class Command(BaseCommand):
@@ -8,26 +25,12 @@ class Command(BaseCommand):
 
     def __init__(self):
         super(Command, self).__init__()
-        self.logger = CommandLogger(self.stdout, self.stderr)
+        self.creator = ShareGroupCreator(self.stdout, self.stderr)
 
     def add_arguments(self, parser):
         parser.add_argument('group_name', help='Name of the share group to create')
         parser.add_argument('--usernames', help='User to add to share group', nargs='*')
         parser.add_argument('--dds_ids', help='DukeDS UUID of user', nargs='*')
-
-    def _create_share_group(self, group_name):
-        share_group, created = ShareGroup.objects.get_or_create(name=group_name)
-        self.logger.log_creation(created, 'ShareGroup', group_name, share_group.id)
-        return share_group
-
-    def _create_dds_user(self, name, dds_id):
-        dds_user, created = DDSUser.objects.get_or_create(name=name, dds_id=dds_id)
-        self.logger.log_creation(created, 'DDSUser', name, dds_user.id)
-        return dds_user
-
-    def _add_dds_user_to_share_group(self, dds_user, share_group):
-        share_group.users.add(dds_user)
-        self.logger.log('Added {} to share group {}'.format(dds_user, share_group))
 
     def handle(self, **options):
         group_name = options['group_name']
@@ -37,9 +40,9 @@ class Command(BaseCommand):
         if not len(usernames) == len(dds_ids):
             raise CommandError('usernames and dds_ids must be equal length')
 
-        share_group = self._create_share_group(group_name)
+        share_group = self.creator.create_share_group(group_name)
 
         for username, dds_id in zip(usernames, dds_ids):
-            dds_user = self._create_dds_user(username, dds_id)
-            self._add_dds_user_to_share_group(dds_user, share_group)
+            dds_user = self.creator.create_dds_user(username, dds_id)
+            self.creator.add_dds_user_to_share_group(dds_user, share_group)
 


### PR DESCRIPTION
Since questionnaires cannot be loaded without share groups, it's necessary to be able to create them early. This includes two changes

1. `loadworkflow` takes a share group name argument, and it will create a `ShareGroup` with no users if none are found
2. `makesharegroup` creates a `ShareGroup` and `DDSUser`s with provided details

```
python manage.py makesharegroup mygroup --usernames user1 user2 --dds_ids dds-id-1 dds-id-2
```

Fixes #59 