### PR TITLE
Allow normal users to view share group names

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -258,5 +258,11 @@ class AdminJobTokensViewSet(viewsets.ModelViewSet):
 
 class AdminShareGroupViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.IsAdminUser,)
+    serializer_class = AdminShareGroupSerializer
+    queryset = ShareGroup.objects.all()
+
+
+class ShareGroupViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = (permissions.IsAuthenticated,)
     serializer_class = ShareGroupSerializer
     queryset = ShareGroup.objects.all()

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -64,7 +64,7 @@ class JobSerializer(serializers.ModelSerializer):
         resource_name = 'jobs'
         fields = ('id', 'workflow_version', 'user', 'name', 'created', 'state', 'step', 'last_updated',
                   'vm_flavor', 'vm_instance_name', 'vm_volume_name', 'vm_project_name', 'job_order',
-                  'output_dir', 'job_errors', 'stage_group', 'volume_size', 'fund_code')
+                  'output_dir', 'job_errors', 'stage_group', 'volume_size', 'fund_code', 'share_group')
 
 
 class UserSerializer(serializers.Serializer):
@@ -249,6 +249,13 @@ class DDSUserSerializer(serializers.ModelSerializer):
 
 
 class ShareGroupSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ShareGroup
+        resource_name = 'share-groups'
+        fields = ('id', 'name',)
+
+
+class AdminShareGroupSerializer(serializers.ModelSerializer):
     users = DDSUserSerializer(many=True, read_only=True)
     class Meta:
         model = ShareGroup

--- a/data/urls.py
+++ b/data/urls.py
@@ -17,6 +17,7 @@ router.register(r'job-errors', api.JobErrorViewSet, 'joberror')
 router.register(r'job-output-dirs', api.JobOutputDirViewSet, 'joboutputdir')
 router.register(r'job-questionnaires', api.JobQuestionnaireViewSet, 'jobquestionnaire')
 router.register(r'job-answer-sets', api.JobAnswerSetViewSet, 'jobanswerset')
+router.register(r'share-groups', api.ShareGroupViewSet, 'sharegroup')
 
 # Routes that require admin user
 router.register(r'admin/jobs', api.AdminJobsViewSet, 'admin_job')


### PR DESCRIPTION
Adds ability for users to view share group name for changes related to https://github.com/Duke-GCB/bespin-ui/issues/52. Adds user level share group endpoint similar to pre-existing admin share group. Adds share-group to job serializer.