### PR TITLE
JSON API Validation errors - add source

### DIFF
--- a/data/exception_handlers.py
+++ b/data/exception_handlers.py
@@ -34,8 +34,6 @@ def make_json_root_error(status_code, data, exc):
 
 
 def json_root_object_exception_handler(exc, context):
-    if isinstance(exc, ValidationError):  # EmberJS requires 422 for client validation errors
-        exc.status_code = 422
     # Call REST framework's default exception handler first,
     # to get the standard error response.
     response = exception_handler(exc, context)

--- a/data/exception_handlers.py
+++ b/data/exception_handlers.py
@@ -1,5 +1,4 @@
 from rest_framework.views import exception_handler
-from rest_framework.exceptions import ValidationError
 from renderers import JSONRootObjectRenderer
 
 SOURCE_POINTER_PREFIX = '/data/attributes'

--- a/data/exception_handlers.py
+++ b/data/exception_handlers.py
@@ -1,5 +1,8 @@
 from rest_framework.views import exception_handler
+from rest_framework.exceptions import ValidationError
 from renderers import JSONRootObjectRenderer
+
+SOURCE_POINTER_PREFIX = '/data/attributes'
 
 
 def switching_exception_handler(exc, context):
@@ -16,13 +19,23 @@ def make_json_root_error(status_code, data, exc):
     if isinstance(data, str):
         error['detail'] = data
     elif isinstance(data, dict):
-        error['detail'] = data.get('detail')
-        if data.get('id'):
+        if 'detail' in data:
+            error['detail'] = data['detail']
+        else:
+            for key in data.keys():
+                value = data[key]
+                error['source'] = {
+                    'pointer': '{}/{}'.format(SOURCE_POINTER_PREFIX, key)
+                }
+                error['detail'] = value
+        if 'id' in data:
             error['id'] = data.get('id')
     return error
 
 
 def json_root_object_exception_handler(exc, context):
+    if isinstance(exc, ValidationError):  # EmberJS requires 422 for client validation errors
+        exc.status_code = 422
     # Call REST framework's default exception handler first,
     # to get the standard error response.
     response = exception_handler(exc, context)
@@ -31,7 +44,6 @@ def json_root_object_exception_handler(exc, context):
     # return appropriate responses. For now, we'll just return None from the handler to aid ongoing development
     if response is None:
         return None
-
     # response.data may be list or a single object
     if isinstance(response.data, list):
         errors = [make_json_root_error(response.status_code, data, exc) for data in response.data]

--- a/data/tests_exception_handlers.py
+++ b/data/tests_exception_handlers.py
@@ -21,7 +21,7 @@ class SwitchingExceptionHandlerTestCase(TestCase):
 
 class MakeJsonRootErrorTestCase(TestCase):
 
-    def test_makes_error_object_from_dict(self):
+    def test_makes_error_object_from_dict_with_detail(self):
         status_code = 401
         exc = MagicMock()
         data = {'detail': 'Detail message', 'id': 6}
@@ -30,6 +30,16 @@ class MakeJsonRootErrorTestCase(TestCase):
         self.assertEqual(error['detail'], 'Detail message',
                          'JSON root error should use the data detail as the detail message')
         self.assertEqual(error['id'], 6, 'With a dict containing id, JSON root error should include this id')
+
+    def test_makes_error_object_from_dict_with_field_keys(self):
+        status_code = 400
+        exc = MagicMock()
+        data = {'jobName': 'Some value'}
+        error = make_json_root_error(status_code, data, exc)
+        self.assertEqual(error['status'], status_code, 'JSON root error should contain the status code')
+        self.assertEqual(error['detail'], 'Some value',
+                         'JSON root error should use the key values as the detail message')
+        self.assertEqual(error['source'], {'pointer': '/data/attributes/jobName'})
 
     def test_makes_error_object_from_str(self):
         status_code = 401


### PR DESCRIPTION
EmberJS requires optional 'source' attribute and requires status code 422 for validation errors.
https://emberjs.com/api/ember-data/2.14/classes/DS.RESTAdapter/properties?anchor=#success-and-failure&show=inherited,protected,private,deprecated
https://emberjs.com/api/ember-data/2.14/classes/DS.RESTSerializer/methods/extractId?anchor=extractErrors

Changes are required by https://github.com/Duke-GCB/bespin-ui/issues/51

I will fix the ember side to handle 400 instead of the WebDav 422.