### PR TITLE
Allow users to delete un-started jobs

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -79,6 +79,7 @@ class WorkflowVersionsViewSet(viewsets.ReadOnlyModelViewSet):
 
 class JobsViewSet(mixins.RetrieveModelMixin,
                   mixins.ListModelMixin,
+                  mixins.DestroyModelMixin,
                   viewsets.GenericViewSet):
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = JobSerializer
@@ -132,6 +133,14 @@ class JobsViewSet(mixins.RetrieveModelMixin,
         job = Job.objects.get(pk=pk)
         serializer = JobSerializer(job)
         return Response(serializer.data, status=job_status)
+
+    def destroy(self, request, *args, **kwargs):
+        job = self.get_object()
+        # Only delete job if it hasn't been started yet
+        if job.state not in [Job.JOB_STATE_NEW, Job.JOB_STATE_AUTHORIZED]:
+            raise BespinAPIException(400, 'You may only delete jobs in NEW and AUTHORIZED states.')
+        self.perform_destroy(job)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class AdminJobsViewSet(viewsets.ModelViewSet):

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -644,6 +644,34 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['detail'], 'This token has already been used.')
 
+    def test_delete_job(self):
+        normal_user = self.user_login.become_normal_user()
+        values = [
+            # job state         expected response status code
+            (Job.JOB_STATE_NEW, status.HTTP_204_NO_CONTENT),
+            (Job.JOB_STATE_AUTHORIZED, status.HTTP_204_NO_CONTENT),
+            (Job.JOB_STATE_STARTING, status.HTTP_400_BAD_REQUEST),
+            (Job.JOB_STATE_RUNNING, status.HTTP_400_BAD_REQUEST),
+            (Job.JOB_STATE_FINISHED, status.HTTP_400_BAD_REQUEST),
+            (Job.JOB_STATE_ERROR, status.HTTP_400_BAD_REQUEST),
+            (Job.JOB_STATE_CANCELING, status.HTTP_400_BAD_REQUEST),
+            (Job.JOB_STATE_CANCEL, status.HTTP_400_BAD_REQUEST),
+            (Job.JOB_STATE_RESTARTING, status.HTTP_400_BAD_REQUEST),
+        ]
+        for job_state, expected_response_status_code in values:
+            job = Job.objects.create(workflow_version=self.workflow_version,
+                                     vm_project_name='jpb67',
+                                     job_order={},
+                                     user=normal_user,
+                                     stage_group=JobFileStageGroup.objects.create(user=normal_user),
+                                     share_group=self.share_group,
+                                     )
+            job.state = job_state
+            job.save()
+            url = reverse('job-list') + str(job.id) + '/'
+            response = self.client.delete(url)
+            self.assertEqual(response.status_code, expected_response_status_code)
+
 
 class JobStageGroupTestCase(APITestCase):
     def setUp(self):


### PR DESCRIPTION
Allows users to delete a job if NEW or AUTHORIZED.
Fixes #76