### PR TITLE
Adds a /users/current-user API endpoint

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -7,12 +7,13 @@ from django.db import IntegrityError
 
 from data.serializers import *
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import detail_route, list_route
 from lando import LandoJob
 from django.db.models import Q
 from django.db import transaction
 from jobfactory import create_job_factory
 from mailer import EmailMessageSender, JobMailer
+
 
 class DDSViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
@@ -226,6 +227,17 @@ class JobErrorViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return JobError.objects.filter(job__user=self.request.user)
+
+
+class UserViewSet(viewsets.GenericViewSet):
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = UserSerializer
+
+    @list_route(methods=['get'], url_path='current-user')
+    def current_user(self, request):
+        current_user = self.request.user
+        serializer = UserSerializer(self.request.user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class AdminJobErrorViewSet(viewsets.ModelViewSet):

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from django.contrib.auth.models import User
 from data.models import Workflow, WorkflowVersion, Job, DDSJobInputFile, JobFileStageGroup, \
     DDSEndpoint, DDSUserCredential, JobOutputDir, URLJobInputFile, JobError, JobAnswerSet, \
     JobQuestionnaire, VMFlavor, VMProject, JobToken, ShareGroup, DDSUser, WorkflowMethodsDocument, \
@@ -69,6 +70,7 @@ class JobSerializer(serializers.ModelSerializer):
     user = serializers.PrimaryKeyRelatedField(read_only=True, default=serializers.CurrentUserDefault())
     job_errors = JobErrorSerializer(required=False, read_only=True, many=True)
     run_token = serializers.CharField(required=False, read_only=True, source='run_token.token')
+
     class Meta:
         model = Job
         resource_name = 'jobs'
@@ -78,9 +80,11 @@ class JobSerializer(serializers.ModelSerializer):
                   'run_token',)
 
 
-class UserSerializer(serializers.Serializer):
-    id = serializers.IntegerField(required=False)
-    username = serializers.CharField()
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        resource_name = 'users'
+        fields = ('id', 'username', 'first_name', 'last_name', 'email',)
 
 
 class AdminJobSerializer(serializers.ModelSerializer):

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -1661,6 +1661,12 @@ class UserTestCase(APITestCase):
     def setUp(self):
         self.user_login = UserLogin(self.client)
 
+    def test_requires_login(self):
+        self.user_login.become_unauthorized()
+        url = reverse('user-current-user')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
     def test_cannot_list(self):
         with self.assertRaises(NoReverseMatch):
             reverse('user-list')

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User as django_user
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, NoReverseMatch
 from mock.mock import MagicMock, patch, Mock
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -1654,4 +1654,49 @@ class EmailTemplateTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         created = EmailTemplate.objects.first()
         self.assertEqual('error-template', created.name)
+
+
+class UserTestCase(APITestCase):
+
+    def setUp(self):
+        self.user_login = UserLogin(self.client)
+
+    def test_cannot_list(self):
+        with self.assertRaises(NoReverseMatch):
+            reverse('user-list')
+
+    def test_get_current_user(self):
+        self.user_login.become_normal_user()
+        url = reverse('user-current-user')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['username'], 'user')
+
+        self.user_login.become_other_normal_user()
+        url = reverse('user-current-user')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['username'], 'user2')
+
+    def test_cannot_change(self):
+        self.user_login.become_normal_user()
+        url = reverse('user-current-user')
+        response = self.client.put(url, {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        response = self.client.post(url, {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        response = self.client.delete(url, {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_cannot_get_by_id(self):
+        self.user_login.become_normal_user()
+        url = reverse('user-current-user')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['username'], 'user')
+        user_id = response.data['id']
+        self.assertIsNotNone(django_user.objects.get(id=user_id))
+        detail_url = '{}/{}'.format(url, user_id)
+        response = self.client.get(detail_url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/data/urls.py
+++ b/data/urls.py
@@ -19,6 +19,7 @@ router.register(r'job-questionnaires', api.JobQuestionnaireViewSet, 'jobquestion
 router.register(r'job-answer-sets', api.JobAnswerSetViewSet, 'jobanswerset')
 router.register(r'share-groups', api.ShareGroupViewSet, 'sharegroup')
 router.register(r'workflow-methods-documents', api.WorkflowMethodsDocumentViewSet, 'workflowmethodsdocument')
+router.register(r'users', api.UserViewSet, 'user')
 
 # Routes that require admin user
 router.register(r'admin/jobs', api.AdminJobsViewSet, 'admin_job')


### PR DESCRIPTION
- This API endpoint returns the current user object, and does not allow any other listing or modification
- The UserSerializer has been updated to include additional user details (name, email)
