### PR TITLE
loadworkflow methods template can now use description

### DIFF
--- a/data/management/commands/loadworkflow.py
+++ b/data/management/commands/loadworkflow.py
@@ -74,7 +74,8 @@ class CWLDocument(object):
 
 
 class MethodsDocumentContents(object):
-    def __init__(self, software_requirement_hints, jinja_template_url):
+    def __init__(self, workflow_version_description, software_requirement_hints, jinja_template_url):
+        self.workflow_version_description = workflow_version_description
         self.software_requirement_hints = software_requirement_hints
         self.jinja_template_url = jinja_template_url
 
@@ -91,6 +92,7 @@ class MethodsDocumentContents(object):
                 else:
                     apa_citation = citation
                 template_args[package_name] = {'version': versions[-1], 'citation': apa_citation}
+        template_args['description'] = self.workflow_version_description
         response = requests.get(self.jinja_template_url)
         response.raise_for_status()
         template = Template(response.text)
@@ -210,7 +212,7 @@ class WorkflowImporter(BaseCreator):
             version=self.version_number,
         )
         software_requirement_hints = document.extract_tool_hints(hint_class_name="SoftwareRequirement")
-        methods_document = MethodsDocumentContents(software_requirement_hints,
+        methods_document = MethodsDocumentContents(workflow_version_description, software_requirement_hints,
                                                    jinja_template_url=self.methods_jinja_template_url)
         WorkflowMethodsDocument.objects.get_or_create(
             workflow_version=workflow_version,

--- a/data/management/commands/tests_loadworkflow.py
+++ b/data/management/commands/tests_loadworkflow.py
@@ -70,13 +70,14 @@ class MethodsDocumentContentsTestCase(TestCase):
                 ]
             }
         ]
-        jinja_template = """sometool version:{{sometool.version}} citation: {{sometool.citation}}
+        jinja_template = """desc: {{description}} sometool version:{{sometool.version}} citation: {{sometool.citation}}
 othertool version: {{othertool.version}} citation: {{othertool.citation}}"""
-        expected_content = """sometool version:1 citation: someurl
+        expected_content = """desc: A good workflow sometool version:1 citation: someurl
 othertool version: 3 citation: Dr Man 2017"""
         mock_requests.get.return_value = Mock(text=jinja_template)
         mock_cn.content_negotiation.return_value = 'Dr Man 2017'
         method_document_contents = MethodsDocumentContents(
+            workflow_version_description='A good workflow',
             software_requirement_hints=software_requirement_hints,
             jinja_template_url='fakeurl')
         self.assertEqual(expected_content, method_document_contents.get_content())


### PR DESCRIPTION
This will let templates optionally include the workflow version description.

This feature has been used here: https://github.com/Duke-GCB/bespin-cwl/pull/37