### PR TITLE
Allows API requests to "DELETE" jobs Finished, Cancel, or Error states

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -92,7 +92,7 @@ class JobsViewSet(mixins.RetrieveModelMixin,
     serializer_class = JobSerializer
 
     def get_queryset(self):
-        return Job.objects.filter(user=self.request.user)
+        return Job.objects.filter(user=self.request.user).exclude(state=Job.JOB_STATE_DELETED)
 
     @detail_route(methods=['post'])
     def start(self, request, pk=None):

--- a/data/models.py
+++ b/data/models.py
@@ -130,6 +130,7 @@ class Job(models.Model):
     JOB_STATE_CANCELING = 'c'
     JOB_STATE_CANCEL = 'C'
     JOB_STATE_RESTARTING = 'r'
+    JOB_STATE_DELETED = 'D'
     JOB_STATES = (
         (JOB_STATE_NEW, 'New'),
         (JOB_STATE_AUTHORIZED, 'Authorized'),
@@ -140,6 +141,7 @@ class Job(models.Model):
         (JOB_STATE_CANCELING, 'Canceling'),
         (JOB_STATE_CANCEL, 'Canceled'),
         (JOB_STATE_RESTARTING, 'Restarting'),
+        (JOB_STATE_DELETED, 'Deleted'),
     )
 
     JOB_STEP_CREATE_VM = 'V'

--- a/data/models.py
+++ b/data/models.py
@@ -195,6 +195,10 @@ class Job(models.Model):
             raise ValidationError('stage group user does not match job user')
         super(Job, self).save(*args, **kwargs)
 
+    def mark_deleted(self):
+        self.state = Job.JOB_STATE_DELETED
+        self.save()
+
     class Meta:
         ordering = ['created']
 


### PR DESCRIPTION
Job records do not get deleted, but get set to `D` state and removed from user API results
