### PR TITLE
Add vm name filtering to /api/admin/jobs enpint

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -163,6 +163,8 @@ class AdminJobsViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.IsAdminUser,)
     serializer_class = AdminJobSerializer
     queryset = Job.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('vm_instance_name',)
 
     def perform_update(self, serializer):
         # Overrides perform update to notify about state changes

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -431,6 +431,30 @@ class JobsTestCase(APITestCase):
         self.assertEqual(1, len(response.data))
         self.assertEqual(response.data[0]['state'], 'D')
 
+    def testAdminFilterJobsVmInstanceName(self):
+        admin_user = self.user_login.become_admin_user()
+        Job.objects.create(name='somejob',
+                           workflow_version=self.workflow_version,
+                           vm_project_name='jpb67',
+                           vm_instance_name='vm_job_1',
+                           job_order={},
+                           user=admin_user,
+                           share_group=self.share_group,
+                           )
+        Job.objects.create(name='somejob2',
+                           workflow_version=self.workflow_version,
+                           vm_project_name='jpb67',
+                           vm_instance_name='vm_job_2',
+                           job_order={},
+                           user=admin_user,
+                           share_group=self.share_group,
+                           )
+        url = reverse('admin_job-list') + '?vm_instance_name=vm_job_1'
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(1, len(response.data))
+        self.assertEqual('somejob', response.data[0]['name'])
+
     def test_settings_effect_job_cleanup_vm(self):
         admin_user = self.user_login.become_admin_user()
         job = Job.objects.create(name='somejob',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ lando-messaging==0.7.2
 mock==2.0.0
 pbr==1.10.0
 pika==0.10.0
-psycopg2==2.6.2
+psycopg2==2.7.3.2
 PyYAML==3.12
 requests==2.11.1
 six==1.10.0


### PR DESCRIPTION
Allows users to filter jobs based on vm_instance_name.
Fixes https://github.com/Duke-GCB/lando/issues/101
Lando code assumed that this filter already existed.