### PR TITLE
use postgres when running circleci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs:
     working_directory: ~/circleci-demo-python-django
     docker:
       - image: circleci/python:2.7
-        environement:
-          DATABASE_URL: postgres://root/circle_test
+        environment:
+          DATABASE_URL: postgres://root@localhost:5432/circle_test
       - image: circleci/postgres:9.5
         environment:
           POSTGRES_USER: root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/circleci-demo-python-django
     docker:
       - image: circleci/python:2.7
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/circleci-demo-python-django
+    docker:
+      - image: circleci/python:2.7
+        environement:
+          DATABASE_URL: postgres://root/circle_test
+      - image: circleci/postgres:9.5
+        environment:
+          POSTGRES_USER: root
+          POSTGRES_DB: circle_test
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - run:
+          command: |
+            virtualenv venv
+            source venv/bin/activate
+            pip install -r requirements.txt
+      - save_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          command: |
+            source venv/bin/activate
+            python manage.py test
+      - store_artifacts:
+          path: test-reports/
+          destination: tr1

--- a/bespin/settings.py
+++ b/bespin/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 from bespin.settings_base import *
+import dj_database_url
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '+u!*o@^1!elg34r5u$z4xgq(_yq@fqw!d^4p6y*zh_o1buifsa'
@@ -32,6 +33,10 @@ DATABASES = {
         # 'ATOMIC_REQUESTS': True,
     }
 }
+# Update database configuration from $DATABASE_URL if set
+db_from_env = dj_database_url.config()
+DATABASES['default'].update(db_from_env)
+
 
 # So that pages served by ember development server are listed as OK to access this API
 CORS_ORIGIN_WHITELIST = (

--- a/data/api.py
+++ b/data/api.py
@@ -223,7 +223,7 @@ class DDSEndpointViewSet(viewsets.ModelViewSet):
 class DDSUserCredViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
     serializer_class = ReadOnlyDDSUserCredSerializer
-    queryset = DDSUserCredential.objects.all()
+    queryset = DDSUserCredential.objects.all().order_by('id')
 
 
 class AdminDDSUserCredentialsViewSet(viewsets.ReadOnlyModelViewSet):

--- a/data/test_lando.py
+++ b/data/test_lando.py
@@ -63,7 +63,7 @@ class LandoJobTests(TestCase):
         mock_give_download_permissions.assert_has_calls([
             call(self.user, '1234', '5432'),
             call(self.user, '1235', '5432')
-        ])
+        ], any_order=True)
 
     @patch('data.lando.LandoJob._make_client')
     @patch('data.lando.give_download_permissions')
@@ -76,4 +76,4 @@ class LandoJobTests(TestCase):
         mock_give_download_permissions.assert_has_calls([
             call(self.user, '1234', '5432'),
             call(self.user, '1235', '5432')
-        ])
+        ], any_order=True)

--- a/data/tests_models.py
+++ b/data/tests_models.py
@@ -320,7 +320,7 @@ class JobTests(TestCase):
                                       vm_settings=self.vm_settings,
                                       vm_flavor=self.vm_flavor,
                                       )
-        self.assertTrue(str(raised_error.exception).startswith('UNIQUE constraint failed'))
+        self.assertIn("unique constraint", str(raised_error.exception).lower())
 
     def test_job_activity_creation(self):
         # Create job which should start in new state
@@ -664,7 +664,7 @@ class JobTokenTests(TestCase):
         JobToken.objects.create(token='secret1')
         with self.assertRaises(IntegrityError) as raised_error:
             JobToken.objects.create(token='secret1')
-        self.assertTrue(str(raised_error.exception).startswith('UNIQUE constraint failed'))
+        self.assertIn('unique constraint', str(raised_error.exception).lower())
 
 
 class DDSUserTests(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Django==1.10.1
 django-cors-headers==1.3.1
 django-filter==1.0.1
 djangorestframework==3.4.7
+dj-database-url==0.4.2
 DukeDSClient==0.3.18
 funcsigs==1.0.2
 gcb-web-auth==0.7


### PR DESCRIPTION
Fixes #119 

Here we are testing against our current deployment versions:
- python: 2.7
- postgres: 9.5

Uses [dj-database-url](https://github.com/kennethreitz/dj-database-url) to simplify test database setup.