### PR TITLE
Moves required group out to settings or env variable

### DIFF
--- a/bespin/backend.py
+++ b/bespin/backend.py
@@ -1,13 +1,12 @@
 from gcb_web_auth.backends.oauth import OAuth2Backend
-
-BESPIN_USER_GROUP = 'duke:group-manager:roles:bespin-users'
+from django.conf import settings
 
 
 class BespinOAuth2Backend(OAuth2Backend):
     """
-    Adds check to make sure users belong to the bespin-user group manager group.
-    This group is managed via https://groups.oit.duke.edu/groupmanager/.
+    If required by settings, checks that user belongs to group-manager group
     """
     def check_user_details(self, details):
-        duke_unique_id = details['dukeUniqueID']
-        self.verify_user_belongs_to_group(duke_unique_id, BESPIN_USER_GROUP)
+        if settings.REQUIRED_GROUP_MANAGER_GROUP:
+            duke_unique_id = details['dukeUniqueID']
+            self.verify_user_belongs_to_group(duke_unique_id, settings.REQUIRED_GROUP_MANAGER_GROUP)

--- a/bespin/settings_base.py
+++ b/bespin/settings_base.py
@@ -128,3 +128,5 @@ REST_FRAMEWORK = {
     ),
     'EXCEPTION_HANDLER': 'drf_ember_backend.exception_handlers.switching_exception_handler',
 }
+
+REQUIRED_GROUP_MANAGER_GROUP = None

--- a/bespin/settings_prod.py
+++ b/bespin/settings_prod.py
@@ -54,3 +54,5 @@ else:
 if os.getenv('BESPIN_SMTP_HOST') is not None:
   EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
   EMAIL_HOST = os.getenv('BESPIN_SMTP_HOST')
+
+REQUIRED_GROUP_MANAGER_GROUP = os.getenv('BESPIN_REQUIRED_GROUPMANAGER_GROUP')

--- a/bespin/test_backend.py
+++ b/bespin/test_backend.py
@@ -1,0 +1,25 @@
+from django.test.utils import override_settings
+from django.test import TestCase
+from mock import patch
+
+from backend import BespinOAuth2Backend
+
+class BespinOAuth2BackendTestCase(TestCase):
+
+    def setUp(self):
+        self.details = {'dukeUniqueID': 'abc123'}
+
+    @override_settings(REQUIRED_GROUP_MANAGER_GROUP='test-group')
+    @patch('bespin.backend.BespinOAuth2Backend.verify_user_belongs_to_group')
+    def test_check_user_details_verifies_required_group(self, mock_verify):
+        backend = BespinOAuth2Backend()
+        backend.check_user_details(self.details)
+        self.assertTrue(mock_verify.called)
+        self.assertTrue(mock_verify.call_args('abc123','test-group'))
+
+    @override_settings(REQUIRED_GROUP_MANAGER_GROUP=None)
+    @patch('bespin.backend.BespinOAuth2Backend.verify_user_belongs_to_group')
+    def test_check_user_details_skips_empty_group(self, mock_verify):
+        backend = BespinOAuth2Backend()
+        backend.check_user_details(self.details)
+        self.assertFalse(mock_verify.called)

--- a/bespin/test_backend.py
+++ b/bespin/test_backend.py
@@ -19,7 +19,14 @@ class BespinOAuth2BackendTestCase(TestCase):
 
     @override_settings(REQUIRED_GROUP_MANAGER_GROUP=None)
     @patch('bespin.backend.BespinOAuth2Backend.verify_user_belongs_to_group')
-    def test_check_user_details_skips_empty_group(self, mock_verify):
+    def test_check_user_details_skips_none_group(self, mock_verify):
+        backend = BespinOAuth2Backend()
+        backend.check_user_details(self.details)
+        self.assertFalse(mock_verify.called)
+
+    @override_settings(REQUIRED_GROUP_MANAGER_GROUP='')
+    @patch('bespin.backend.BespinOAuth2Backend.verify_user_belongs_to_group')
+    def test_check_user_details_skips_emptystring_group(self, mock_verify):
         backend = BespinOAuth2Backend()
         backend.check_user_details(self.details)
         self.assertFalse(mock_verify.called)


### PR DESCRIPTION
- Group membership checking now defaults to off (allowing all users).
- To enforce group membership checks, set the group name in `settings.REQUIRED_GROUPMANAGER_GROUP`
- Updates `settings_prod.py` to look for `BESPIN_REQUIRED_GROUPMANAGER_GROUP` variable, which will be provided by deployment when necessary
- Adds a testcase for this behavior

Fixes #46 