### PR TITLE
Token management

### DIFF
--- a/data/serializers.py
+++ b/data/serializers.py
@@ -89,16 +89,13 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class TokenSerializer(serializers.ModelSerializer):
-    id = serializers.SerializerMethodField("get_key")
+    id = serializers.CharField(source='key', read_only=True)
 
     class Meta:
         model = Token
         resource_name = 'tokens'
         fields = ('id', 'created')
         read_only_fields = ('created', 'user',)
-
-    def get_key(self, obj):
-        return obj.key
 
 
 class VMProjectSerializer(serializers.ModelSerializer):

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -5,6 +5,7 @@ from data.models import Workflow, WorkflowVersion, Job, DDSJobInputFile, JobFile
     JobQuestionnaire, VMFlavor, VMProject, JobToken, ShareGroup, DDSUser, WorkflowMethodsDocument, \
     EmailTemplate, EmailMessage, VMSettings, CloudSettings, JobActivity
 from data.jobsummary import JobSummary
+from rest_framework.authtoken.models import Token
 
 
 class WorkflowSerializer(serializers.ModelSerializer):
@@ -85,6 +86,19 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         resource_name = 'users'
         fields = ('id', 'username', 'first_name', 'last_name', 'email',)
+
+
+class TokenSerializer(serializers.ModelSerializer):
+    id = serializers.SerializerMethodField("get_key")
+
+    class Meta:
+        model = Token
+        resource_name = 'tokens'
+        fields = ('id', 'created')
+        read_only_fields = ('created', 'user',)
+
+    def get_key(self, obj):
+        return obj.key
 
 
 class VMProjectSerializer(serializers.ModelSerializer):

--- a/data/urls.py
+++ b/data/urls.py
@@ -21,6 +21,7 @@ router.register(r'job-activities', api.JobActivityViewSet, 'jobactivity')
 router.register(r'share-groups', api.ShareGroupViewSet, 'sharegroup')
 router.register(r'workflow-methods-documents', api.WorkflowMethodsDocumentViewSet, 'workflowmethodsdocument')
 router.register(r'users', api.UserViewSet, 'user')
+router.register(r'tokens', api.TokenViewSet, 'token')
 
 # Routes that require admin user
 router.register(r'admin/jobs', api.AdminJobsViewSet, 'admin_job')


### PR DESCRIPTION
Adds api endpoints for managing tokens: `/api/tokens/`.
Using existing drf Token model. 
This model has a unique user constraint so a user can only have one at a time.
Adds API endpoint to allow list, create and delete.
Serializer renames key to id to be ember compatible.