### PR TITLE
Upgrade to DukeDSClient 1.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==1.0.1
 djangorestframework==3.4.7
 dj-database-url==0.4.2
 drf-ember-backend==1.1
-DukeDSClient==1.0.1
+DukeDSClient==1.0.5
 funcsigs==1.0.2
 gcb-web-auth==1.0.1
 habanero==0.5.0


### PR DESCRIPTION
Fixes #145 
bespin-api uses the default value for D4S2 supplied by DukeDSClient.
DukeDSClient version 1.0.2 updated the D4S2 url to the new value.
Upgrading to the latest version of DukeDSClient.

