### PR TITLE
add usage to job details

### DIFF
--- a/data/api.py
+++ b/data/api.py
@@ -153,7 +153,7 @@ class JobsViewSet(mixins.RetrieveModelMixin,
         serializer = JobTokensSerializer(job.run_token)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['post'], serializer_class=JobUsageSerializer)
+    @detail_route(methods=['post'], serializer_class=JobUsageSerializer, url_path='live-usage')
     def live_usage(self, request, pk=None):
         try:
             job = Job.objects.get(pk=pk)

--- a/data/api.py
+++ b/data/api.py
@@ -153,12 +153,12 @@ class JobsViewSet(mixins.RetrieveModelMixin,
         serializer = JobTokensSerializer(job.run_token)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @detail_route(methods=['post'], serializer_class=JobSummarySerializer)
-    def summary(self, request, pk=None):
+    @detail_route(methods=['post'], serializer_class=JobUsageSerializer)
+    def live_usage(self, request, pk=None):
         try:
             job = Job.objects.get(pk=pk)
-            summary = JobSummary(job)
-            serializer = JobSummarySerializer(summary)
+            live_usage = JobUsage(job)
+            serializer = JobUsageSerializer(live_usage)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Job.DoesNotExist:
             raise NotFound("Job {} not found.".format(pk))

--- a/data/jobusage.py
+++ b/data/jobusage.py
@@ -4,7 +4,7 @@ import datetime
 SECONDS_IN_AN_HOUR = 3600.0
 
 
-class JobSummary(object):
+class JobUsage(object):
     def __init__(self, job):
         self.job = job
         self.vm_hours = self._calculate_vm_hours()

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -4,7 +4,7 @@ from data.models import Workflow, WorkflowVersion, Job, DDSJobInputFile, JobFile
     DDSEndpoint, DDSUserCredential, JobDDSOutputProject, URLJobInputFile, JobError, JobAnswerSet, \
     JobQuestionnaire, VMFlavor, VMProject, JobToken, ShareGroup, DDSUser, WorkflowMethodsDocument, \
     EmailTemplate, EmailMessage, VMSettings, CloudSettings, JobActivity
-from data.jobsummary import JobSummary
+from data.jobusage import JobUsage
 from rest_framework.authtoken.models import Token
 
 
@@ -71,21 +71,21 @@ class JobSerializer(serializers.ModelSerializer):
     user = serializers.PrimaryKeyRelatedField(read_only=True, default=serializers.CurrentUserDefault())
     job_errors = JobErrorSerializer(required=False, read_only=True, many=True)
     run_token = serializers.CharField(required=False, read_only=True, source='run_token.token')
-    summary = serializers.SerializerMethodField()
+    usage = serializers.SerializerMethodField()
 
-    def get_summary(self, job):
+    def get_usage(self, job):
         """
-        Return summary suitable for displaying in a list to compare jobs.
-        Since the summary information (vm hours/cpu hours) for running jobs is not comparable against complete jobs
-        the summary will be None for jobs in this state.
+        Return job usage suitable for displaying in a list to compare jobs.
+        Since the usage information (vm hours/cpu hours) for running jobs is not comparable against complete jobs
+        the usage will be None for jobs in this state.
         :param job: Job
-        :return: dict of job summary data or None if in running state
+        :return: dict of job usage data or None if in running state
         """
         if job.state == Job.JOB_STATE_RUNNING:
             return None
         else:
-            summary = JobSummary(job)
-            serializer = JobSummarySerializer(summary)
+            usage = JobUsage(job)
+            serializer = JobUsageSerializer(usage)
             return serializer.data
 
     class Meta:
@@ -94,7 +94,7 @@ class JobSerializer(serializers.ModelSerializer):
         fields = ('id', 'workflow_version', 'user', 'name', 'created', 'state', 'step', 'last_updated',
                   'vm_settings', 'vm_instance_name', 'vm_volume_name', 'job_order',
                   'output_project', 'job_errors', 'stage_group', 'volume_size', 'fund_code', 'share_group',
-                  'run_token', 'summary')
+                  'run_token', 'usage')
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -317,11 +317,11 @@ class JobTokensSerializer(serializers.ModelSerializer):
         fields = ('token', 'job')
 
 
-class JobSummarySerializer(serializers.Serializer):
+class JobUsageSerializer(serializers.Serializer):
     vm_hours = serializers.FloatField()
     cpu_hours = serializers.FloatField()
     class Meta:
-        resource_name = 'job-summaries'
+        resource_name = 'job-usage'
 
 
 class DDSUserSerializer(serializers.ModelSerializer):

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -897,23 +897,23 @@ class JobsTestCase(APITestCase):
         url = reverse('job-list')
         normal_user = self.user_login.become_normal_user()
         job1 = Job.objects.create(name='job1',
-                                 workflow_version=self.workflow_version,
-                                 job_order={},
-                                 user=normal_user,
-                                 share_group=self.share_group,
-                                 vm_settings=self.vm_settings,
-                                 vm_flavor=self.vm_flavor,
-                                 state=Job.JOB_STATE_FINISHED
-                                 )
+                                  workflow_version=self.workflow_version,
+                                  job_order={},
+                                  user=normal_user,
+                                  share_group=self.share_group,
+                                  vm_settings=self.vm_settings,
+                                  vm_flavor=self.vm_flavor,
+                                  state=Job.JOB_STATE_FINISHED
+                                  )
         job2 = Job.objects.create(name='job2',
-                                 workflow_version=self.workflow_version,
-                                 job_order={},
-                                 user=normal_user,
-                                 share_group=self.share_group,
-                                 vm_settings=self.vm_settings,
-                                 vm_flavor=self.vm_flavor,
-                                 state=Job.JOB_STATE_RUNNING
-                                 )
+                                  workflow_version=self.workflow_version,
+                                  job_order={},
+                                  user=normal_user,
+                                  share_group=self.share_group,
+                                  vm_settings=self.vm_settings,
+                                  vm_flavor=self.vm_flavor,
+                                  state=Job.JOB_STATE_RUNNING
+                                  )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(2, len(response.data))

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -884,7 +884,7 @@ class JobsTestCase(APITestCase):
                                  vm_settings=self.vm_settings,
                                  vm_flavor=self.vm_flavor,
                                  )
-        url = reverse('job-list') + str(job.id) + '/live_usage/'
+        url = reverse('job-list') + str(job.id) + '/live-usage/'
         # Post to /cancel/ for job should work
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -890,6 +890,38 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['vm_hours'], 1.2)
 
+    @patch('data.serializers.JobSummary')
+    def test_summary_included_in_jobs_list(self, mock_job_summary):
+        mock_job_summary.return_value.vm_hours = 1.2
+        mock_job_summary.return_value.cpu_hours = 1.2
+        url = reverse('job-list')
+        normal_user = self.user_login.become_normal_user()
+        job1 = Job.objects.create(name='job1',
+                                 workflow_version=self.workflow_version,
+                                 job_order={},
+                                 user=normal_user,
+                                 share_group=self.share_group,
+                                 vm_settings=self.vm_settings,
+                                 vm_flavor=self.vm_flavor,
+                                 state=Job.JOB_STATE_FINISHED
+                                 )
+        job2 = Job.objects.create(name='job2',
+                                 workflow_version=self.workflow_version,
+                                 job_order={},
+                                 user=normal_user,
+                                 share_group=self.share_group,
+                                 vm_settings=self.vm_settings,
+                                 vm_flavor=self.vm_flavor,
+                                 state=Job.JOB_STATE_RUNNING
+                                 )
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(2, len(response.data))
+        self.assertEqual(response.data[0]['id'], job1.id)
+        self.assertEqual(response.data[0]['summary'], {'cpu_hours': 1.2, 'vm_hours': 1.2})
+        self.assertEqual(response.data[1]['id'], job2.id)
+        self.assertEqual(response.data[1]['summary'], None)
+
 
 class JobStageGroupTestCase(APITestCase):
     def setUp(self):

--- a/data/tests_api.py
+++ b/data/tests_api.py
@@ -871,9 +871,9 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['run_token'], 'test-token')
 
-    @patch('data.api.JobSummary')
-    def test_job_summary(self, mock_job_summary):
-        mock_job_summary.return_value.vm_hours = 1.2
+    @patch('data.api.JobUsage')
+    def test_job_usage(self, mock_job_usage):
+        mock_job_usage.return_value.vm_hours = 1.2
         normal_user = self.user_login.become_normal_user()
         stage_group = JobFileStageGroup.objects.create(user=normal_user)
         job = Job.objects.create(workflow_version=self.workflow_version,
@@ -884,16 +884,16 @@ class JobsTestCase(APITestCase):
                                  vm_settings=self.vm_settings,
                                  vm_flavor=self.vm_flavor,
                                  )
-        url = reverse('job-list') + str(job.id) + '/summary/'
+        url = reverse('job-list') + str(job.id) + '/live_usage/'
         # Post to /cancel/ for job should work
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['vm_hours'], 1.2)
 
-    @patch('data.serializers.JobSummary')
-    def test_summary_included_in_jobs_list(self, mock_job_summary):
-        mock_job_summary.return_value.vm_hours = 1.2
-        mock_job_summary.return_value.cpu_hours = 1.2
+    @patch('data.serializers.JobUsage')
+    def test_usage_included_in_jobs_list(self, mock_job_usage):
+        mock_job_usage.return_value.vm_hours = 1.2
+        mock_job_usage.return_value.cpu_hours = 1.2
         url = reverse('job-list')
         normal_user = self.user_login.become_normal_user()
         job1 = Job.objects.create(name='job1',
@@ -918,9 +918,9 @@ class JobsTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(2, len(response.data))
         self.assertEqual(response.data[0]['id'], job1.id)
-        self.assertEqual(response.data[0]['summary'], {'cpu_hours': 1.2, 'vm_hours': 1.2})
+        self.assertEqual(response.data[0]['usage'], {'cpu_hours': 1.2, 'vm_hours': 1.2})
         self.assertEqual(response.data[1]['id'], job2.id)
-        self.assertEqual(response.data[1]['summary'], None)
+        self.assertEqual(response.data[1]['usage'], None)
 
 
 class JobStageGroupTestCase(APITestCase):


### PR DESCRIPTION
Adds `usage` to job details.
Renames JobSummary to JobUsage.
Renames `/api/jobs/<id>/summary` to `/api/jobs/<id>/live_usage`.
