### PR TITLE
use django timezone for getting now

### DIFF
--- a/data/jobusage.py
+++ b/data/jobusage.py
@@ -1,5 +1,6 @@
 from models import Job
 import datetime
+from django.utils import timezone
 
 SECONDS_IN_AN_HOUR = 3600.0
 
@@ -46,7 +47,7 @@ class JobUsage(object):
         if next_activity:
             end_datetime = next_activity.created
         else:
-            end_datetime = datetime.datetime.now()
+            end_datetime = timezone.now()
         time_delta = end_datetime - activity.created
         elapsed_seconds = time_delta.total_seconds()
         return elapsed_seconds / SECONDS_IN_AN_HOUR

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cwltool==1.0.20170525215327
+cwltool==1.0.20180906112546
 html5lib==0.999999999
 Django==1.10.1
 django-cors-headers==1.3.1
@@ -19,5 +19,5 @@ pika==0.10.0
 psycopg2==2.7.3.2
 PyYAML==3.12
 requests==2.11.1
-schema-salad==2.7.20180611133406
+schema-salad==2.7.20180905124720
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ pika==0.10.0
 psycopg2==2.7.3.2
 PyYAML==3.12
 requests==2.11.1
-schema-salad==2.7.2018061113340
+schema-salad==2.7.20180611133406
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ pika==0.10.0
 psycopg2==2.7.3.2
 PyYAML==3.12
 requests==2.11.1
+schema-salad==2.7.2018061113340
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cwltool==1.0.20180906112546
+cwltool==1.0.20180525185854
 html5lib==0.999999999
 Django==1.10.1
 django-cors-headers==1.3.1
@@ -19,5 +19,4 @@ pika==0.10.0
 psycopg2==2.7.3.2
 PyYAML==3.12
 requests==2.11.1
-schema-salad==2.7.20180905124720
 six==1.10.0


### PR DESCRIPTION
This will take into account if django is using timezones.
Fixes #151 

Updates cwltool to fix [issue with installation related to schema-salad requirements](https://circleci.com/gh/Duke-GCB/bespin-api/405)