### PR TITLE
disable javascript validation for loading cwl workflow

### DIFF
--- a/data/importers.py
+++ b/data/importers.py
@@ -1,7 +1,9 @@
 from data.models import Workflow, WorkflowVersion, JobQuestionnaire, VMFlavor, VMProject, \
     VMSettings, ShareGroup, WorkflowMethodsDocument, JobQuestionnaireType
+from cwltool import workflow
 from cwltool.load_tool import load_tool
-from cwltool.workflow import defaultMakeTool
+from cwltool.context import LoadingContext, getdefault
+from cwltool.resolver import tool_resolver
 import sys
 import requests
 import json
@@ -58,7 +60,13 @@ class CWLDocument(object):
         :return: The CWL document, parsed into a dict
         """
         if self._parsed is None:
-            self._parsed = load_tool(self.url + '#main', defaultMakeTool)
+            context = LoadingContext()
+            context.construct_tool_object = getdefault(
+                context.construct_tool_object, workflow.default_make_tool)
+            context.disable_js_validation = True
+            context.resolver = getdefault(context.resolver, tool_resolver)
+
+            self._parsed = load_tool(self.url + '#main', context)
         return self._parsed
 
     @property

--- a/data/importers.py
+++ b/data/importers.py
@@ -1,9 +1,10 @@
 from data.models import Workflow, WorkflowVersion, JobQuestionnaire, VMFlavor, VMProject, \
     VMSettings, ShareGroup, WorkflowMethodsDocument, JobQuestionnaireType
-from cwltool import workflow
-from cwltool.load_tool import load_tool
-from cwltool.context import LoadingContext, getdefault
+from cwltool.context import LoadingContext
+from cwltool.workflow import default_make_tool
 from cwltool.resolver import tool_resolver
+from cwltool.load_tool import load_tool
+import cwltool.factory
 import sys
 import requests
 import json
@@ -60,12 +61,9 @@ class CWLDocument(object):
         :return: The CWL document, parsed into a dict
         """
         if self._parsed is None:
-            context = LoadingContext()
-            context.construct_tool_object = getdefault(
-                context.construct_tool_object, workflow.default_make_tool)
-            context.disable_js_validation = True
-            context.resolver = getdefault(context.resolver, tool_resolver)
-
+            context = LoadingContext({"construct_tool_object": default_make_tool,
+                                      "resolver": tool_resolver,
+                                      "disable_js_validation": True})
             self._parsed = load_tool(self.url + '#main', context)
         return self._parsed
 

--- a/data/importers.py
+++ b/data/importers.py
@@ -4,7 +4,6 @@ from cwltool.context import LoadingContext
 from cwltool.workflow import default_make_tool
 from cwltool.resolver import tool_resolver
 from cwltool.load_tool import load_tool
-import cwltool.factory
 import sys
 import requests
 import json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cwltool==1.0.20180525185854
+cwltool==1.0.20180923172926
 html5lib==0.999999999
 Django==1.10.1
 django-cors-headers==1.3.1


### PR DESCRIPTION
Upgrades version of cwltool used to parse workflow. 
Updates code to use the new method to load a workflow. 
Removes the requirement to have nodejs installed on the server running nodejs.

Fixes #154 
Fixes #153 