### PR TITLE
Update READMEs about docker build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,12 @@ $ python manage.py runserver
 
 # Docker Build Details
 
-Docker Cloud is configured to automatically build the master branch and tags of `bespin-api`, producing docker images that run bespin-api in development mode:
+The [Dockerfile](Dockerfile) in the repo root builds `bespin-api` in a development configuration (running django's web server).
 
-```
-master -> dukegcb/bespin-api:latest
-v1.0.0 -> dukegcb/bespin-api:1.0.0
-```
+    docker build -t bespin-api .
 
-For automated builds of production-ready images, there is a second [Dockerfile](apache-docker/Dockerfile) in   [apache-docker](apache-docker). We use Docker Cloud's [custom build phase hooks](https://docs.docker.com/docker-cloud/builds/advanced/#custom-build-phase-hooks) in the [hooks](hooks) directory build and push `-apache` variations of the bespin-api images.
+To build a production-ready image (Apache with mod\_wsgi), use the [Dockerfile](apache-docker/Dockerfile) in the apache-docker subdirectory, specifying the prior image name as the BASE\_IMAGE argument:
 
-The [post\_build](hooks/post_build) and [post\_push](../hooks/post_push) hooks produce docker images that run bespin-api in production mode:
+    docker build --build-arg BASE_IMAGE=bespin-api -t bespin-api:apache apache-docker
 
-```
-master -> dukegcb/bespin-api:latest-apache
-v1.0.0 -> dukegcb/bespin-api:1.0.0-apache
-```
-
-See [apache-docker](apache-docker) for more details, including
+See [apache-docker](apache-docker) for more details on running the production-ready image.

--- a/apache-docker/README.md
+++ b/apache-docker/README.md
@@ -7,10 +7,10 @@ Dockerfile for building bespin-api with apache2 and mod_wsgi
 
 The Dockerfile contained is used to build an image containing the bespin-api Django application, hosted by Apache httpd using wsgi.
 
-The Ember frontend application, [bespin-ui](https://github.com/Duke-GCB/bespin-ui) is not included in the image, but should be downloaded from its release and mounted at runtime in the container at `/srv/ui/`. The [bespin-web](https://github.com/Duke-GCB/gcb-ansible-roles/blob/8976879aa85d5f920a0d9ae30f81bc988baa40a7/bespin_web/tasks/run-server.yml) ansible role documents how bespin-ui is installed.
+The Ember frontend application, [bespin-ui](https://github.com/Duke-GCB/bespin-ui) is not included in the image, but should be built for production and mounted at runtime in the container at `/srv/ui/`.
+
+ The [bespin\_web](https://github.com/Duke-GCB/gcb-ansible-roles/blob/master/bespin_web/tasks/run-server.yml) ansible role illustrates how the built Ember application can be served from a Docker volume.
 
 # Docker Build Details
 
-The [Dockerfile](Dockerfile) requires a build-time argument to specify the `FROM` image. Specifying the `FROM` image allows Docker Cloud to automatically build an `-apache` variation for each tagged version of the `bespin-api` image.
-
-Docker cloud is configured to build `bespin-api` tags and branches. The [post-build hook](../hooks/post_build) builds the `-apache` variation and the [post-push hook](../hooks/post_push) pushes the apache variation.
+The [Dockerfile](Dockerfile) requires a build-time argument to specify the `FROM` image. This may be automated as in the [build\_docker\_image](https://github.com/Duke-GCB/gcb-ansible-roles/blob/master/build_docker_image/tasks/main.yml) ansible role, or built with the [docker command](https://docs.docker.com/engine/reference/commandline/build/)

--- a/hooks/post_build
+++ b/hooks/post_build
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# After building bespin-api, now build the image based on it
-echo "Building ${IMAGE_NAME}-apache from apache-docker context"
-
-docker build --build-arg BASE_IMAGE=${IMAGE_NAME} -t ${IMAGE_NAME}-apache apache-docker

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# After pushing bespin-api, push the apache version
-echo "Pushing ${IMAGE_NAME}-apache"
-
-docker push ${IMAGE_NAME}-apache


### PR DESCRIPTION
- Docker images are now built by ansible
- Remove hooks directory with scripts used by docker cloud builds