### PR TITLE
Add cloud settings to v2 jobs API

### DIFF
--- a/bespin_api_v2/serializers.py
+++ b/bespin_api_v2/serializers.py
@@ -9,7 +9,7 @@ from bespin_api_v2.jobtemplate import JobTemplate, WorkflowVersionConfiguration,
     REQUIRED_ERROR_MESSAGE, PLACEHOLDER_ERROR_MESSAGE
 from data.serializers import JobFileStageGroupSerializer, AdminDDSUserCredSerializer, \
     JobErrorSerializer, AdminJobDDSOutputProjectSerializer, AdminShareGroupSerializer, \
-    WorkflowMethodsDocumentSerializer, JobDDSOutputProjectSerializer, UserSerializer
+    WorkflowMethodsDocumentSerializer, JobDDSOutputProjectSerializer, UserSerializer, AdminCloudSettingsSerializer
 from data.jobusage import JobUsage
 
 
@@ -113,10 +113,12 @@ class AdminJobRuntimeOpenStack(serializers.ModelSerializer):
     cwl_base_command = JSONStrField()
     cwl_post_process_command = JSONStrField()
     cwl_pre_process_command = JSONStrField()
+    cloud_settings = AdminCloudSettingsSerializer(read_only=True, required=False)
     class Meta:
         model = JobRuntimeOpenStack
         resource_name = 'job-runtime-open-stack'
-        fields = ('image_name', 'cwl_base_command', 'cwl_post_process_command', 'cwl_pre_process_command')
+        fields = ('image_name', 'cwl_base_command', 'cwl_post_process_command', 'cwl_pre_process_command',
+                  'cloud_settings', )
 
 
 class AdminJobRuntimeStepK8s(serializers.ModelSerializer):

--- a/bespin_api_v2/tests_api.py
+++ b/bespin_api_v2/tests_api.py
@@ -817,8 +817,8 @@ class JobsTestCase(APITestCase):
         self.assertEqual(job_runtime_openstack['cwl_base_command'], ['cwltool'])
         self.assertEqual(job_runtime_openstack['cwl_post_process_command'], ['cleanup.sh'])
         self.assertEqual(job_runtime_openstack['cwl_pre_process_command'], ['prep.sh'])
-        self.assertEqual(job_runtime_openstack['cloud_settings']['name'], 'something')
-        self.assertEqual(job_runtime_openstack['cloud_settings']['vm_project']['name'], 'something')
+        self.assertEqual(job_runtime_openstack['cloud_settings']['name'], 'cloud')
+        self.assertEqual(job_runtime_openstack['cloud_settings']['vm_project']['name'], 'project1')
 
     def test_admin_jobs_list_shows_k8s_job_settings(self):
         admin_user = self.user_login.become_admin_user()

--- a/bespin_api_v2/tests_api.py
+++ b/bespin_api_v2/tests_api.py
@@ -817,6 +817,8 @@ class JobsTestCase(APITestCase):
         self.assertEqual(job_runtime_openstack['cwl_base_command'], ['cwltool'])
         self.assertEqual(job_runtime_openstack['cwl_post_process_command'], ['cleanup.sh'])
         self.assertEqual(job_runtime_openstack['cwl_pre_process_command'], ['prep.sh'])
+        self.assertEqual(job_runtime_openstack['cloud_settings']['name'], 'something')
+        self.assertEqual(job_runtime_openstack['cloud_settings']['vm_project']['name'], 'something')
 
     def test_admin_jobs_list_shows_k8s_job_settings(self):
         admin_user = self.user_login.become_admin_user()


### PR DESCRIPTION
Adds `cloud_settings` to v2 `jobs` API.
Fixes #198 