### PR TITLE
copy email endpoints to v2

### DIFF
--- a/bespin_api_v2/api.py
+++ b/bespin_api_v2/api.py
@@ -8,13 +8,13 @@ from bespin_api_v2.serializers import AdminWorkflowSerializer, AdminWorkflowVers
     WorkflowConfigurationSerializer, JobTemplateMinimalSerializer, JobTemplateSerializer, WorkflowVersionSerializer, \
     ShareGroupSerializer, JobTemplateValidatingSerializer, AdminJobSerializer, JobFileStageGroupSerializer, \
     AdminDDSUserCredSerializer, JobErrorSerializer, AdminJobDDSOutputProjectSerializer, AdminShareGroupSerializer, \
-    WorkflowMethodsDocumentSerializer, JobSerializer
+    WorkflowMethodsDocumentSerializer, JobSerializer, AdminEmailMessageSerializer, AdminEmailTemplateSerializer
 from gcb_web_auth.models import DDSUserCredential
 from data.api import JobsViewSet as V1JobsViewSet
 from data.models import Workflow, WorkflowVersion, JobStrategy, WorkflowConfiguration, JobFileStageGroup, ShareGroup, \
-    Job, JobError, JobDDSOutputProject, WorkflowMethodsDocument
+    Job, JobError, JobDDSOutputProject, WorkflowMethodsDocument, EmailMessage, EmailTemplate
 from data.exceptions import BespinAPIException
-from data.mailer import JobMailer
+from data.mailer import EmailMessageSender, JobMailer
 
 
 class CreateListRetrieveModelViewSet(mixins.CreateModelMixin,
@@ -162,3 +162,26 @@ class WorkflowMethodsDocumentViewSet(viewsets.ReadOnlyModelViewSet):
 
 class JobsViewSet(V1JobsViewSet):
     serializer_class = JobSerializer
+
+
+class AdminEmailMessageViewSet(viewsets.ModelViewSet):
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = AdminEmailMessageSerializer
+    queryset = EmailMessage.objects.all()
+
+    @detail_route(methods=['post'], url_path='send')
+    def send(self, request, pk=None):
+        """
+        Send an email message
+        """
+        message = self.get_object()
+        sender = EmailMessageSender(message)
+        sender.send()
+        serializer = self.get_serializer(message)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class AdminEmailTemplateViewSet(viewsets.ModelViewSet):
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = AdminEmailTemplateSerializer
+    queryset = EmailTemplate.objects.all()

--- a/bespin_api_v2/serializers.py
+++ b/bespin_api_v2/serializers.py
@@ -3,7 +3,8 @@ from rest_framework import serializers, fields, permissions, viewsets
 from django.contrib.auth.models import User
 from data.models import Workflow, WorkflowVersion, JobStrategy, WorkflowConfiguration, JobFileStageGroup, \
     ShareGroup, JobFlavor, Job, JobDDSOutputProject, DDSJobInputFile, URLJobInputFile, JobError, DDSUser, \
-    WorkflowMethodsDocument, JobSettings, LandoConnection, JobRuntimeOpenStack, JobRuntimeK8s, JobRuntimeStepK8s
+    WorkflowMethodsDocument, JobSettings, LandoConnection, JobRuntimeOpenStack, JobRuntimeK8s, JobRuntimeStepK8s, \
+    EmailTemplate, EmailMessage
 from gcb_web_auth.models import DDSEndpoint, DDSUserCredential
 from bespin_api_v2.jobtemplate import JobTemplate, WorkflowVersionConfiguration, JobTemplateValidator, \
     REQUIRED_ERROR_MESSAGE, PLACEHOLDER_ERROR_MESSAGE
@@ -206,3 +207,17 @@ class JobSerializer(serializers.ModelSerializer):
                   'job_settings', 'vm_instance_name', 'vm_volume_name', 'job_order',
                   'output_project', 'job_errors', 'stage_group', 'volume_size', 'fund_code', 'share_group',
                   'run_token', 'usage')
+
+
+class AdminEmailTemplateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EmailTemplate
+        resource_name = 'email-templates'
+        fields = '__all__'
+
+
+class AdminEmailMessageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EmailMessage
+        resource_name = 'email-messages'
+        fields = '__all__'

--- a/bespin_api_v2/tests_api.py
+++ b/bespin_api_v2/tests_api.py
@@ -5,7 +5,7 @@ from rest_framework import status
 from data.tests_api import UserLogin
 from data.models import Workflow, WorkflowVersion, WorkflowConfiguration, JobStrategy, ShareGroup, JobFlavor, \
     JobSettings, CloudSettingsOpenStack, VMProject, JobFileStageGroup, DDSUserCredential, DDSEndpoint, Job, \
-    JobRuntimeK8s, LandoConnection, JobRuntimeStepK8s
+    JobRuntimeK8s, LandoConnection, JobRuntimeStepK8s, EmailMessage, EmailTemplate
 from data.tests_models import create_vm_job_settings
 from bespin_api_v2.jobtemplate import STRING_VALUE_PLACEHOLDER, INT_VALUE_PLACEHOLDER, \
     REQUIRED_ERROR_MESSAGE, PLACEHOLDER_ERROR_MESSAGE
@@ -1053,3 +1053,193 @@ class JobsTestCase(APITestCase):
                                     })
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(mock_mail_current_state.called)
+
+
+class EmailMessageTestCase(APITestCase):
+
+    def setUp(self):
+        self.user_login = UserLogin(self.client)
+
+    def test_admin_only_allow_admin_users(self):
+        url = reverse('v2-admin_emailmessage-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.user_login.become_normal_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.user_login.become_admin_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_admin_list(self):
+        EmailMessage.objects.create(
+            body='body1',
+            subject='subject1',
+            sender_email='sender1@example.com',
+            to_email='recipient1@university.edu',
+        )
+        EmailMessage.objects.create(
+            body='body2',
+            subject='subject2',
+            sender_email='sender2@example.com',
+            to_email='recipient2@university.edu',
+        )
+        EmailMessage.objects.create(
+            body='body3',
+            subject='subject3',
+            sender_email='sender3@example.com',
+            to_email='recipient3@university.edu',
+        )
+
+        url = reverse('v2-admin_emailmessage-list')
+        self.user_login.become_admin_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(3, len(response.data))
+        messages = response.data
+
+        self.assertEqual('body1', messages[0]['body'])
+        self.assertEqual('body2', messages[1]['body'])
+        self.assertEqual('body3', messages[2]['body'])
+
+    def test_admin_read_single_message(self):
+        message = EmailMessage.objects.create(
+            body='body1',
+            subject='subject1',
+            sender_email='sender1@example.com',
+            to_email='recipient1@university.edu',
+        )
+
+        url = reverse('v2-admin_emailmessage-detail', args=[message.id])
+        self.user_login.become_admin_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual('body1', response.data['body'])
+        self.assertEqual('subject1', response.data['subject'])
+        self.assertEqual('sender1@example.com', response.data['sender_email'])
+        self.assertEqual('recipient1@university.edu', response.data['to_email'])
+        self.assertEqual('N', response.data['state'])
+
+    def test_admin_create_message(self):
+        message_dict = {
+            'body': 'Email message body',
+            'subject': 'Subject',
+            'sender_email': 'fred@school.edu',
+            'to_email': 'wilma@company.com'
+        }
+        url = reverse('v2-admin_emailmessage-list')
+        self.user_login.become_admin_user()
+        response = self.client.post(url, format='json', data=message_dict)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created = EmailMessage.objects.first()
+        self.assertEqual('Subject', created.subject)
+        self.assertEqual('Email message body', created.body)
+        self.assertEqual('fred@school.edu', created.sender_email)
+        self.assertEqual('wilma@company.com', created.to_email)
+
+    @patch('data.mailer.DjangoEmailMessage')
+    def test_admin_send_message(self, MockSender):
+        message = EmailMessage.objects.create(
+            body='body1',
+            subject='subject1',
+            sender_email='sender1@example.com',
+            to_email='recipient1@university.edu',
+        )
+        url = reverse('v2-admin_emailmessage-detail', args=[message.id])  + 'send/'
+        self.user_login.become_admin_user()
+        response = self.client.post(url, format='json', data={})
+        self.assertTrue(MockSender.called)
+        self.assertTrue(MockSender.return_value.send.called)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual('S', response.data['state'])
+
+    @patch('data.mailer.DjangoEmailMessage')
+    def test_admin_send_message_with_error(self, MockSender):
+        MockSender.return_value.send.side_effect = Exception()
+        message = EmailMessage.objects.create(
+            body='body1',
+            subject='subject1',
+            sender_email='sender1@example.com',
+            to_email='recipient1@university.edu',
+        )
+        url = reverse('v2-admin_emailmessage-detail', args=[message.id])  + 'send/'
+        self.user_login.become_admin_user()
+        response = self.client.post(url, format='json', data={})
+        self.assertTrue(MockSender.called)
+        self.assertTrue(MockSender.return_value.send.called)
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        message = EmailMessage.objects.get(id=message.id)
+        self.assertEqual(message.state, 'E')
+
+
+class EmailTemplateTestCase(APITestCase):
+
+    def setUp(self):
+        self.user_login = UserLogin(self.client)
+
+    def test_admin_only_allow_admin_users(self):
+        url = reverse('v2-admin_emailtemplate-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.user_login.become_normal_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.user_login.become_admin_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_admin_list(self):
+        EmailTemplate.objects.create(
+            name='template1',
+            body_template='body_template1',
+            subject_template='subject_template1',
+        )
+        EmailTemplate.objects.create(
+            name='template2',
+            body_template='body_template2',
+            subject_template='subject_template2',
+        )
+        EmailTemplate.objects.create(
+            name='template3',
+            body_template='body_template3',
+            subject_template='subject_template3',
+        )
+
+        url = reverse('v2-admin_emailtemplate-list')
+        self.user_login.become_admin_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(3, len(response.data))
+        messages = response.data
+
+        self.assertEqual('body_template1', messages[0]['body_template'])
+        self.assertEqual('body_template2', messages[1]['body_template'])
+        self.assertEqual('body_template3', messages[2]['body_template'])
+
+    def test_admin_read_single_template(self):
+        template = EmailTemplate.objects.create(
+            name='template1',
+            body_template='body1',
+            subject_template='subject1',
+        )
+
+        url = reverse('v2-admin_emailtemplate-detail', args=[template.id])
+        self.user_login.become_admin_user()
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual('template1', response.data['name'])
+        self.assertEqual('body1', response.data['body_template'])
+        self.assertEqual('subject1', response.data['subject_template'])
+
+    def test_admin_create_template(self):
+        template_dict = {
+            'name': 'error-template',
+            'body_template': 'The following error occurred {{ error }}',
+            'subject_template': 'Error for job {{ job.name }}',
+        }
+        url = reverse('v2-admin_emailtemplate-list')
+        self.user_login.become_admin_user()
+        response = self.client.post(url, format='json', data=template_dict)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        created = EmailTemplate.objects.first()
+        self.assertEqual('error-template', created.name)

--- a/bespin_api_v2/urls.py
+++ b/bespin_api_v2/urls.py
@@ -26,6 +26,8 @@ router.register(r'admin/job-errors', api.AdminJobErrorViewSet, 'v2-admin_joberro
 router.register(r'admin/job-dds-output-projects', api.AdminJobDDSOutputProjectViewSet, 'v2-admin_jobddsoutputproject')
 router.register(r'admin/share-groups', api.AdminShareGroupViewSet, 'v2-admin_sharegroup')
 router.register(r'admin/workflow-methods-documents', api.WorkflowMethodsDocumentViewSet, 'v2-admin_workflowmethodsdocument')
+router.register(r'admin/email-templates', api.AdminEmailTemplateViewSet, 'v2-admin_emailtemplate')
+router.register(r'admin/email-messages', api.AdminEmailMessageViewSet, 'v2-admin_emailmessage')
 
 urlpatterns = [
     url(r'^', include(router.urls)),


### PR DESCRIPTION
This is to fix an issue where [bespin mailer](https://github.com/Duke-GCB/bespin-mailer) tried to use v2 api. Also copies the tests to v2.

Fixes #197 