### PR TITLE
fix workflow versions sorting

### DIFF
--- a/bespin_api_v2/api.py
+++ b/bespin_api_v2/api.py
@@ -10,7 +10,7 @@ from bespin_api_v2.serializers import AdminWorkflowSerializer, AdminWorkflowVers
     AdminDDSUserCredSerializer, JobErrorSerializer, AdminJobDDSOutputProjectSerializer, AdminShareGroupSerializer, \
     WorkflowMethodsDocumentSerializer, JobSerializer, AdminEmailMessageSerializer, AdminEmailTemplateSerializer
 from gcb_web_auth.models import DDSUserCredential
-from data.api import JobsViewSet as V1JobsViewSet
+from data.api import JobsViewSet as V1JobsViewSet, WorkflowVersionSortedListMixin
 from data.models import Workflow, WorkflowVersion, JobStrategy, WorkflowConfiguration, JobFileStageGroup, ShareGroup, \
     Job, JobError, JobDDSOutputProject, WorkflowMethodsDocument, EmailMessage, EmailTemplate
 from data.exceptions import BespinAPIException
@@ -30,7 +30,7 @@ class AdminWorkflowViewSet(CreateListRetrieveModelViewSet):
     queryset = Workflow.objects.all()
 
 
-class AdminWorkflowVersionViewSet(CreateListRetrieveModelViewSet):
+class AdminWorkflowVersionViewSet(WorkflowVersionSortedListMixin, CreateListRetrieveModelViewSet):
     permission_classes = (permissions.IsAdminUser,)
     serializer_class = AdminWorkflowVersionSerializer
     queryset = WorkflowVersion.objects.all()
@@ -53,9 +53,9 @@ class JobStrategyViewSet(viewsets.ReadOnlyModelViewSet):
     filter_fields = ('name',)
 
 
-class WorkflowVersionsViewSet(viewsets.ReadOnlyModelViewSet):
+class WorkflowVersionsViewSet(WorkflowVersionSortedListMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
-    queryset = WorkflowVersion.objects.order_by('workflow', 'version')
+    queryset = WorkflowVersion.objects.all()
     serializer_class = WorkflowVersionSerializer
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('workflow', 'workflow__tag')

--- a/data/api.py
+++ b/data/api.py
@@ -75,7 +75,15 @@ class WorkflowsViewSet(viewsets.ReadOnlyModelViewSet):
     filter_fields = ('tag',)
 
 
-class WorkflowVersionsViewSet(viewsets.ReadOnlyModelViewSet):
+class WorkflowVersionSortedListMixin(object):
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        items = sorted(queryset, key=WorkflowVersion.sort_workflow_then_version_key)
+        serializer = self.get_serializer(items, many=True)
+        return Response(serializer.data)
+
+
+class WorkflowVersionsViewSet(WorkflowVersionSortedListMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (permissions.IsAuthenticated,)
     queryset = WorkflowVersion.objects.all()
     serializer_class = WorkflowVersionSerializer

--- a/data/api.py
+++ b/data/api.py
@@ -76,6 +76,10 @@ class WorkflowsViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class WorkflowVersionSortedListMixin(object):
+    """
+    Overrides list method and returns a list that is sorted using WorkflowVersion.sort_workflow_then_version_key.
+    NOTE: This removes DRF pagination support.
+    """
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         items = sorted(queryset, key=WorkflowVersion.sort_workflow_then_version_key)

--- a/data/models.py
+++ b/data/models.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.contrib.postgres.fields import JSONField
 from gcb_web_auth.models import DDSUserCredential, DDSEndpoint
 import json
+import re
 
 WORKFLOW_VERSION_PART_SORT_DIGITS = 10
 
@@ -66,9 +67,9 @@ class WorkflowVersion(models.Model):
     @staticmethod
     def sort_workflow_then_version_key(workflow_version):
         parts = [workflow_version.workflow.id]
-        for part in workflow_version.version.split("."):
+        for part in re.split("\.|\-", workflow_version.version):
             left_padded_part = part.zfill(WORKFLOW_VERSION_PART_SORT_DIGITS)
-            parts.extend(left_padded_part)
+            parts.append(left_padded_part)
         return parts
 
 

--- a/data/models.py
+++ b/data/models.py
@@ -61,6 +61,17 @@ class WorkflowVersion(models.Model):
     def __str__(self):
         return "WorkflowVersion - pk: {} workflow.pk: {}, version: {}".format(self.pk, self.workflow.pk, self.version,)
 
+    @staticmethod
+    def sort_workflow_then_version_key(workflow_version):
+        parts = [workflow_version.workflow.id]
+        for part in workflow_version.version.split("."):
+            try:
+                int_part = int(part)
+                parts.append(int_part)
+            except ValueError:
+                parts.append(part)
+        return parts
+
 
 class WorkflowMethodsDocument(models.Model):
     """

--- a/data/models.py
+++ b/data/models.py
@@ -5,6 +5,8 @@ from django.contrib.postgres.fields import JSONField
 from gcb_web_auth.models import DDSUserCredential, DDSEndpoint
 import json
 
+WORKFLOW_VERSION_PART_SORT_DIGITS = 10
+
 
 class DDSUser(models.Model):
     """
@@ -65,11 +67,8 @@ class WorkflowVersion(models.Model):
     def sort_workflow_then_version_key(workflow_version):
         parts = [workflow_version.workflow.id]
         for part in workflow_version.version.split("."):
-            try:
-                int_part = int(part)
-                parts.append(int_part)
-            except ValueError:
-                parts.append(part)
+            left_padded_part = part.zfill(WORKFLOW_VERSION_PART_SORT_DIGITS)
+            parts.extend(left_padded_part)
         return parts
 
 

--- a/data/serializers.py
+++ b/data/serializers.py
@@ -9,6 +9,12 @@ from rest_framework.authtoken.models import Token
 
 
 class WorkflowSerializer(serializers.ModelSerializer):
+    versions = serializers.SerializerMethodField()
+
+    def get_versions(self, obj):
+        sorted_versions = sorted(obj.versions.all(), key=WorkflowVersion.sort_workflow_then_version_key)
+        return [version.id for version in sorted_versions]
+
     class Meta:
         model = Workflow
         resource_name = 'workflows'

--- a/data/tests_models.py
+++ b/data/tests_models.py
@@ -157,14 +157,14 @@ class WorkflowVersionTests(TestCase):
 
     def test_create_with_description(self):
         desc = """This is a detailed description of the job."""
-        WorkflowVersion.objects.create(workflow=self.workflow, description=desc, version=1, fields=[])
+        WorkflowVersion.objects.create(workflow=self.workflow, description=desc, version='1', fields=[])
         wv = WorkflowVersion.objects.first()
         self.assertEqual(desc, wv.description)
 
     def test_version_num_and_workflow_are_unique(self):
-        WorkflowVersion.objects.create(workflow=self.workflow, description="one", version=1, fields=[])
+        WorkflowVersion.objects.create(workflow=self.workflow, description="one", version='1', fields=[])
         with self.assertRaises(IntegrityError):
-            WorkflowVersion.objects.create(workflow=self.workflow, description="two", version=1)
+            WorkflowVersion.objects.create(workflow=self.workflow, description="two", version='1')
 
     def test_version_info_url(self):
         WorkflowVersion.objects.create(workflow=self.workflow,
@@ -174,6 +174,17 @@ class WorkflowVersionTests(TestCase):
                                        fields=[])
         wv = WorkflowVersion.objects.first()
         self.assertEqual(wv.version_info_url, 'https://github.com')
+
+    def test_sort_workflow_then_version_key(self):
+        wf = WorkflowVersion.objects.create(workflow=self.workflow, description="one", version='1', fields=[])
+        self.assertEqual(WorkflowVersion.sort_workflow_then_version_key(wf),
+                         [self.workflow.id, '0000000001'])
+        wf.version = '1.2.3'
+        self.assertEqual(WorkflowVersion.sort_workflow_then_version_key(wf),
+                         [self.workflow.id, '0000000001', '0000000002', '0000000003'])
+        wf.version = '1.0.5-alpha'
+        self.assertEqual(WorkflowVersion.sort_workflow_then_version_key(wf),
+                         [self.workflow.id, '0000000001', '0000000000', '0000000005', '00000alpha'])
 
 
 class JobTests(TestCase):


### PR DESCRIPTION
Adds back in WorkflowVersion sorting based on workflow then SemVer version str.
Changes:
- `/api/v2/workflows/` and `/api/v2/workflows/` sort `versions` array field based on  WorkflowVersion.version
- `/api/v1/workflow-versions/`, `/api/v2/workflow-versions/`, and `/api/v2/admin/workflow-versions/` sort by workflow then WorkflowVersion.version

Fixes #208 