### PR TITLE
upgrade to DukeDSClient 2.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,12 +11,12 @@ funcsigs==1.0.2
 gcb-web-auth==1.0.1
 habanero==0.5.0
 inflection==0.3.1
-Jinja2==2.9.6
+Jinja2==2.10.1
 lando-messaging==1.0.0
 mock==2.0.0
 pbr==1.10.0
 pika==0.10.0
 psycopg2==2.7.3.2
-PyYAML==3.12
+PyYAML==5.1
 requests==2.20.1
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==1.0.1
 djangorestframework==3.4.7
 dj-database-url==0.4.2
 drf-ember-backend==1.1
-DukeDSClient==1.0.1
+DukeDSClient==2.1.4
 funcsigs==1.0.2
 gcb-web-auth==1.0.1
 habanero==0.5.0


### PR DESCRIPTION
Upgrades to DukeDSClient version with full S3 backend support.
Bespin-api only lists projects/files/folders and reads/writes project
permissions.