### PR TITLE
Update gcb-web-auth to 1.1.1

### DIFF
--- a/data/util.py
+++ b/data/util.py
@@ -5,7 +5,7 @@ from ddsc.core.remotestore import RemoteStore
 from ddsc.core.ddsapi import DataServiceError
 from ddsc.core.ddsapi import ContentType
 from ddsc.config import Config
-from gcb_web_auth.utils import get_oauth_token, get_dds_token_from_oauth
+from gcb_web_auth.utils import get_oauth_token, get_dds_token_from_oauth, get_default_dds_endpoint
 import requests
 
 
@@ -90,7 +90,7 @@ def get_dds_config(user):
         user_cred = DDSUserCredential.objects.get(user=user)
         config = get_dds_config_for_credentials(user_cred)
     except ObjectDoesNotExist:
-        endpoint_cred = DDSEndpoint.objects.first()
+        endpoint_cred = get_default_dds_endpoint()
         config = create_config_for_endpoint(endpoint_cred)
         oauth_token = get_oauth_token(user)
         user_auth_token = _get_dds_auth_token(endpoint_cred, oauth_token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dj-database-url==0.4.2
 drf-ember-backend==1.1
 DukeDSClient==2.1.4
 funcsigs==1.0.2
-gcb-web-auth==1.0.1
+gcb-web-auth==1.1.1
 habanero==0.5.0
 inflection==0.3.1
 Jinja2==2.10.1


### PR DESCRIPTION
Previously was using 1.0.1, so this PR includes the change to use `get_default_dds_endpoint()` instead of `DDSEndpoint.objects.first()` as implemented in https://github.com/Duke-GCB/gcb-web-auth/pull/33