### PR TITLE
allow admin API to setup/disable a k8s cluster

### DIFF
--- a/bespin_api_v2/api.py
+++ b/bespin_api_v2/api.py
@@ -10,7 +10,7 @@ from bespin_api_v2.serializers import AdminWorkflowSerializer, AdminWorkflowVers
     AdminDDSUserCredSerializer, JobErrorSerializer, AdminJobDDSOutputProjectSerializer, AdminShareGroupSerializer, \
     WorkflowMethodsDocumentSerializer, WorkflowVersionToolDetailsSerializer, JobSerializer, \
     AdminEmailMessageSerializer, AdminEmailTemplateSerializer, AdminLandoConnectionSerializer, \
-    AdminJobStrategySerializer, AdminCreateJobSettingsSerializer
+    AdminJobStrategySerializer, AdminJobSettingsSerializer
 from gcb_web_auth.models import DDSUserCredential
 from data.api import JobsViewSet as V1JobsViewSet, WorkflowVersionSortedListMixin, ExcludeDeprecatedWorkflowsMixin
 from data.models import Workflow, WorkflowVersion, JobStrategy, WorkflowConfiguration, JobFileStageGroup, ShareGroup, \
@@ -213,5 +213,5 @@ class AdminJobStrategyViewSet(CreateListRetrieveModelViewSet, mixins.DestroyMode
 
 class AdminJobSettingsViewSet(CreateListRetrieveModelViewSet):
     permission_classes = (permissions.IsAdminUser,)
-    serializer_class = AdminCreateJobSettingsSerializer
+    serializer_class = AdminJobSettingsSerializer
     queryset = JobSettings.objects.all()

--- a/bespin_api_v2/api.py
+++ b/bespin_api_v2/api.py
@@ -207,6 +207,8 @@ class AdminJobStrategyViewSet(CreateListRetrieveModelViewSet, mixins.DestroyMode
     permission_classes = (permissions.IsAdminUser,)
     serializer_class = AdminJobStrategySerializer
     queryset = JobStrategy.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('name',)
 
 
 class AdminJobSettingsViewSet(CreateListRetrieveModelViewSet):

--- a/bespin_api_v2/api.py
+++ b/bespin_api_v2/api.py
@@ -9,11 +9,13 @@ from bespin_api_v2.serializers import AdminWorkflowSerializer, AdminWorkflowVers
     ShareGroupSerializer, JobTemplateValidatingSerializer, AdminJobSerializer, JobFileStageGroupSerializer, \
     AdminDDSUserCredSerializer, JobErrorSerializer, AdminJobDDSOutputProjectSerializer, AdminShareGroupSerializer, \
     WorkflowMethodsDocumentSerializer, WorkflowVersionToolDetailsSerializer, JobSerializer, \
-    AdminEmailMessageSerializer, AdminEmailTemplateSerializer
+    AdminEmailMessageSerializer, AdminEmailTemplateSerializer, AdminLandoConnectionSerializer, \
+    AdminJobStrategySerializer, AdminCreateJobSettingsSerializer
 from gcb_web_auth.models import DDSUserCredential
 from data.api import JobsViewSet as V1JobsViewSet, WorkflowVersionSortedListMixin, ExcludeDeprecatedWorkflowsMixin
 from data.models import Workflow, WorkflowVersion, JobStrategy, WorkflowConfiguration, JobFileStageGroup, ShareGroup, \
-    Job, JobError, JobDDSOutputProject, WorkflowMethodsDocument, WorkflowVersionToolDetails, EmailMessage, EmailTemplate
+    Job, JobError, JobDDSOutputProject, WorkflowMethodsDocument, WorkflowVersionToolDetails, EmailMessage, \
+    EmailTemplate, LandoConnection, JobSettings
 from data.exceptions import BespinAPIException
 from data.mailer import EmailMessageSender, JobMailer
 
@@ -193,3 +195,21 @@ class AdminEmailTemplateViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.IsAdminUser,)
     serializer_class = AdminEmailTemplateSerializer
     queryset = EmailTemplate.objects.all()
+
+
+class AdminLandoConnectionViewSet(CreateListRetrieveModelViewSet):
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = AdminLandoConnectionSerializer
+    queryset = LandoConnection.objects.all()
+
+
+class AdminJobStrategyViewSet(CreateListRetrieveModelViewSet, mixins.DestroyModelMixin):
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = AdminJobStrategySerializer
+    queryset = JobStrategy.objects.all()
+
+
+class AdminJobSettingsViewSet(CreateListRetrieveModelViewSet):
+    permission_classes = (permissions.IsAdminUser,)
+    serializer_class = AdminCreateJobSettingsSerializer
+    queryset = JobSettings.objects.all()

--- a/bespin_api_v2/serializers.py
+++ b/bespin_api_v2/serializers.py
@@ -225,3 +225,17 @@ class AdminEmailMessageSerializer(serializers.ModelSerializer):
         model = EmailMessage
         resource_name = 'email-messages'
         fields = '__all__'
+
+
+class AdminJobStrategySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = JobStrategy
+        resource_name = 'job-strategies'
+        fields = '__all__'
+
+
+class AdminCreateJobSettingsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = JobSettings
+        resource_name = 'job-settings'
+        fields = '__all__'

--- a/bespin_api_v2/serializers.py
+++ b/bespin_api_v2/serializers.py
@@ -148,13 +148,15 @@ class AdminLandoConnectionSerializer(serializers.ModelSerializer):
 
 
 class AdminJobSettingsSerializer(serializers.ModelSerializer):
-    job_runtime_openstack = AdminJobRuntimeOpenStack(read_only=True)
-    job_runtime_k8s = AdminJobRuntimeK8s(read_only=True)
-
     class Meta:
         model = JobSettings
         resource_name = 'job-settings'
         fields = '__all__'
+
+
+class AdminJobSettingsWithNestedDataSerializer(AdminJobSettingsSerializer):
+    job_runtime_openstack = AdminJobRuntimeOpenStack(read_only=True)
+    job_runtime_k8s = AdminJobRuntimeK8s(read_only=True)
 
 
 class AdminJobSerializer(serializers.ModelSerializer):
@@ -162,7 +164,7 @@ class AdminJobSerializer(serializers.ModelSerializer):
     output_project = JobDDSOutputProjectSerializer(required=False, read_only=True)
     name = serializers.CharField(required=False)
     user = UserSerializer(read_only=True)
-    job_settings = AdminJobSettingsSerializer(read_only=True)
+    job_settings = AdminJobSettingsWithNestedDataSerializer(read_only=True)
     job_flavor = JobFlavorSerializer(read_only=True)
     class Meta:
         model = Job
@@ -231,11 +233,4 @@ class AdminJobStrategySerializer(serializers.ModelSerializer):
     class Meta:
         model = JobStrategy
         resource_name = 'job-strategies'
-        fields = '__all__'
-
-
-class AdminCreateJobSettingsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = JobSettings
-        resource_name = 'job-settings'
         fields = '__all__'

--- a/bespin_api_v2/tests_api.py
+++ b/bespin_api_v2/tests_api.py
@@ -1399,3 +1399,136 @@ class EmailTemplateTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         created = EmailTemplate.objects.first()
         self.assertEqual('error-template', created.name)
+
+
+class AdminLandoConnectionViewSetTestCase(APITestCase, AdminCreateListRetrieveMixin):
+    BASE_NAME = 'v2-admin_landoconnection'
+    MODEL_CLS = LandoConnection
+
+    def setUp(self):
+        self.user_login = UserLogin(self.client)
+
+    def test_list_url(self):
+        self.assertEqual(self.list_url(), '/api/v2/admin/lando-connections/')
+
+    def test_object_url(self):
+        self.assertEqual(self.object_url(3), '/api/v2/admin/lando-connections/3/')
+
+    def create_model_object(self):
+        model_object = LandoConnection.objects.create(
+            cluster_type=LandoConnection.K8S_TYPE,
+            host='somehost',
+            username='user1',
+            password='secret',
+            queue_name='lando'
+        )
+        return model_object
+
+    def check_single_response(self, model_object, response_data):
+        self.assertEqual(response_data['id'], model_object.id)
+        self.assertEqual(response_data['cluster_type'], 'k8s')
+
+    def build_post_data(self):
+        return {
+            'cluster_type': LandoConnection.K8S_TYPE,
+            'host': 'somehost',
+            'username': 'user1',
+            'password': 'secret',
+            'queue_name': 'lando'
+        }
+
+
+class AdminJobStrategyViewSetTestCase(APITestCase, AdminCreateListRetrieveMixin):
+    BASE_NAME = 'v2-admin_jobstrategy'
+    MODEL_CLS = JobStrategy
+
+    def setUp(self):
+        self.user_login = UserLogin(self.client)
+        self.job_flavor = JobFlavor.objects.create(name='large')
+        self.lando_connection = LandoConnection.objects.create(
+            cluster_type=LandoConnection.K8S_TYPE,
+            host='somehost',
+            username='user1',
+            password='secret',
+            queue_name='lando'
+        )
+        self.job_settings = JobSettings.objects.create(
+            lando_connection=self.lando_connection,
+            job_runtime_k8s=JobRuntimeK8s.objects.create())
+
+    def test_list_url(self):
+        self.assertEqual(self.list_url(), '/api/v2/admin/job-strategies/')
+
+    def test_object_url(self):
+        self.assertEqual(self.object_url(3), '/api/v2/admin/job-strategies/3/')
+
+    def create_model_object(self):
+        model_object = JobStrategy.objects.create(
+            name='mystrategy',
+            job_settings=self.job_settings,
+            job_flavor=self.job_flavor
+        )
+        return model_object
+
+    def check_single_response(self, model_object, response_data):
+        self.assertEqual(response_data['id'], model_object.id)
+        self.assertEqual(response_data['name'], 'mystrategy')
+
+    def build_post_data(self):
+        return {
+            'name': 'mystrategy',
+            'job_settings': self.job_settings.id,
+            'job_flavor': self.job_flavor.id
+        }
+
+    def test_delete_fails_with_admin_user(self):
+        # Admin users are allowed to delete, overriding this test so it will not fail
+        pass
+
+    def test_delete_succeeds_with_admin_user(self):
+        model_object = self.create_model_object()
+        self.user_login.become_admin_user()
+        url = self.object_url(model_object.id)
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+
+class AdminJobSettingsViewSetTestCase(APITestCase, AdminCreateListRetrieveMixin):
+    BASE_NAME = 'v2-admin_jobsettings'
+    MODEL_CLS = JobSettings
+
+    def setUp(self):
+        self.user_login = UserLogin(self.client)
+        self.job_flavor = JobFlavor.objects.create(name='large')
+        self.lando_connection = LandoConnection.objects.create(
+            cluster_type=LandoConnection.K8S_TYPE,
+            host='somehost',
+            username='user1',
+            password='secret',
+            queue_name='lando'
+        )
+        self.runtime_k8s = JobRuntimeK8s.objects.create()
+
+    def test_list_url(self):
+        self.assertEqual(self.list_url(), '/api/v2/admin/job-settings/')
+
+    def test_object_url(self):
+        self.assertEqual(self.object_url(3), '/api/v2/admin/job-settings/3/')
+
+    def create_model_object(self):
+        model_object = JobSettings.objects.create(
+            name='mysettings',
+            lando_connection=self.lando_connection,
+            job_runtime_k8s=self.runtime_k8s)
+        return model_object
+
+    def check_single_response(self, model_object, response_data):
+        self.assertEqual(response_data['id'], model_object.id)
+        self.assertEqual(response_data['name'], 'mysettings')
+
+    def build_post_data(self):
+        return {
+            'name': 'mysettings',
+            'lando_connection': self.lando_connection.id,
+            'job_runtime_k8s': self.runtime_k8s.id
+        }

--- a/bespin_api_v2/tests_api.py
+++ b/bespin_api_v2/tests_api.py
@@ -1492,6 +1492,20 @@ class AdminJobStrategyViewSetTestCase(APITestCase, AdminCreateListRetrieveMixin)
         response = self.client.delete(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+    def test_list_filter_by_name(self):
+        JobStrategy.objects.create(name='default', job_flavor=self.job_flavor, job_settings=self.job_settings)
+        JobStrategy.objects.create(name='better', job_flavor=self.job_flavor, job_settings=self.job_settings)
+        self.user_login.become_normal_user()
+        url = reverse('v2-jobstrategies-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(set([item['name'] for item in response.data]), set(['default', 'better']))
+        response = self.client.get(url + "?name=better", format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(set([item['name'] for item in response.data]), set(['better']))
+
 
 class AdminJobSettingsViewSetTestCase(APITestCase, AdminCreateListRetrieveMixin):
     BASE_NAME = 'v2-admin_jobsettings'

--- a/bespin_api_v2/urls.py
+++ b/bespin_api_v2/urls.py
@@ -30,6 +30,9 @@ router.register(r'admin/workflow-methods-documents', api.WorkflowMethodsDocument
 router.register(r'admin/workflow-version-tool-details', api.AdminWorkflowVersionToolDetailsViewSet, 'v2-workflowversiontooldetails')
 router.register(r'admin/email-templates', api.AdminEmailTemplateViewSet, 'v2-admin_emailtemplate')
 router.register(r'admin/email-messages', api.AdminEmailMessageViewSet, 'v2-admin_emailmessage')
+router.register(r'admin/lando-connections', api.AdminLandoConnectionViewSet, 'v2-admin_landoconnection')
+router.register(r'admin/job-strategies', api.AdminJobStrategyViewSet, 'v2-admin_jobstrategy')
+router.register(r'admin/job-settings', api.AdminJobSettingsViewSet, 'v2-admin_jobsettings')
 
 urlpatterns = [
     url(r'^', include(router.urls)),


### PR DESCRIPTION
New admin endpoints:
- `/api/v2/admin/lando-connections/` create/read endpoint to register new rabbitmq queue settings
- `/api/v2/admin/job-settings/` create/read endpoint to register job settings to be used with k8s cluster
- `/api/v2/admin/job-strategies/` create/read/delete endpoint to register and delete job strategies. This  table is not directly linked to the Job so removing a job strategy will prevent new jobs on the k8s cluster. This endpoint allows users to filter by name when listing strategies.

These changes are to allow dynamically setting up a k8s cluster to run jobs on.