### PR TITLE
Upgrade cwltool to fix schema_salad error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cwltool==1.0.20180923172926
+cwltool==1.0.20190915164430
 html5lib==0.999999999
 Django==1.10.1
 django-cors-headers==1.3.1


### PR DESCRIPTION
Changes to the future library in version 0.18 moved the location of past.autotranslate. 
The version of schema_salad failed due to this change.
Upgrading to the latest cwltool which in upgrades to a compatible schema_salad.

Fixes #222